### PR TITLE
feat: add per-call token usage tracking for OCR

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Turn any document into clean Markdown -- in one line.
 - Preserves complex tables (merged cells, rowspan/colspan)
 - One unified API + CLI for single files or entire directories
 - Batch processing with parallel execution
+- Per-call token usage tracking for OpenAI and Vertex AI providers
 
 ## Install
 
@@ -202,6 +203,22 @@ loader = UnifiedDocumentLoader(
     # table_style="markdown_grid",  # markdown with merge annotations
     # table_style="styled_html",    # full HTML with inline styles
 )
+```
+
+### Token usage tracking
+
+When using OpenAI or Vertex AI, each OCR result includes token usage in its metadata:
+
+```python
+from doc2mark import UnifiedDocumentLoader
+
+loader = UnifiedDocumentLoader(ocr_provider="openai")
+result = loader.load("scan.pdf", extract_images=True, ocr_images=True)
+
+# Token usage per OCR call is in result metadata
+usage = result.metadata.get("token_usage", {})
+print(usage)
+# {"input_tokens": 1234, "output_tokens": 567, "total_tokens": 1801}
 ```
 
 ## CLI

--- a/doc2mark/ocr/openai.py
+++ b/doc2mark/ocr/openai.py
@@ -6,7 +6,7 @@ import logging
 import os
 import uuid
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from doc2mark.core.base import OCRError
 from doc2mark.ocr.base import BaseOCR, OCRConfig, OCRProvider, OCRResult, OCRFactory
@@ -172,35 +172,48 @@ class VisionAgent:
             self._llm = ChatOpenAI(**llm_kwargs)
             self._chain = RunnableLambda(prepare_prompt) | self._llm
 
-    def invoke(self, input_dict: Dict[str, str]) -> str:
-        """Process single image using LangChain."""
+    @staticmethod
+    def _extract_usage(msg) -> Dict[str, Any]:
+        """Extract token usage metadata from a LangChain AIMessage."""
+        usage = getattr(msg, 'usage_metadata', None)
+        return dict(usage) if usage else {}
+
+    def invoke(self, input_dict: Dict[str, str]) -> Tuple[str, Dict[str, Any]]:
+        """Process single image using LangChain.
+
+        Returns:
+            Tuple of (processed text, token usage dict)
+        """
         if not self._chain:
             raise RuntimeError("LangChain not available")
 
         result = self._chain.invoke(input_dict)
-        # Replace triple backticks with single backtick in the output
         processed_content = result.content.replace('```', '`') if result.content else result.content
-        return processed_content
+        return processed_content, self._extract_usage(result)
 
-    def batch_invoke(self, input_dicts: List[Dict[str, str]]) -> List[str]:
+    def batch_invoke(self, input_dicts: List[Dict[str, str]]) -> List[Tuple[str, Dict[str, Any]]]:
         """
         Process multiple images using LangChain's efficient batch processing.
-        
-        This uses the same approach as the original ocr_agent.py for optimal performance.
+
+        Returns:
+            List of (processed text, token usage dict) tuples
         """
         if not self._chain:
             raise RuntimeError("LangChain not available")
 
         logger.info(f"🚀 Starting LangChain batch processing of {len(input_dicts)} images")
 
-        # Use LangChain's batch_as_completed for efficient processing
-        results = self._chain.batch_as_completed(input_dicts)  # Returns (index, result) tuples
+        results = self._chain.batch_as_completed(input_dicts)
         sorted_results = sorted(results, key=lambda x: x[0])
 
         logger.info(f"✅ LangChain batch processing complete")
 
-        # Replace triple backticks with single backtick in each output
-        return [res[1].content.replace('```', '`') if res[1].content else res[1].content for res in sorted_results]
+        output = []
+        for res in sorted_results:
+            msg = res[1]
+            text = msg.content.replace('```', '`') if msg.content else msg.content
+            output.append((text, self._extract_usage(msg)))
+        return output
 
 
 class OpenAIOCR(BaseOCR):
@@ -590,7 +603,7 @@ class OpenAIOCR(BaseOCR):
 
             # Convert to OCRResult objects
             results = []
-            for i, text_result in enumerate(batch_results):
+            for i, (text_result, token_usage) in enumerate(batch_results):
                 image_size = len(images[i])
                 results.append(OCRResult(
                     text=text_result,
@@ -606,7 +619,8 @@ class OpenAIOCR(BaseOCR):
                         "image_size_bytes": image_size,
                         "batch_index": i,
                         "content_type": kwargs.get('content_type'),
-                        "model_kwargs": self.model_kwargs
+                        "model_kwargs": self.model_kwargs,
+                        "token_usage": token_usage
                     }
                 ))
 

--- a/doc2mark/ocr/vertex_ai.py
+++ b/doc2mark/ocr/vertex_ai.py
@@ -3,7 +3,7 @@
 import base64
 import logging
 import os
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from doc2mark.core.base import OCRError
 from doc2mark.ocr.base import BaseOCR, OCRConfig, OCRProvider, OCRResult, OCRFactory
@@ -116,16 +116,30 @@ class VertexAIVisionAgent:
             text = str(content)
         return text.replace("```", "`")
 
-    def invoke(self, input_dict: Dict[str, str]) -> str:
-        """Process single image."""
+    @staticmethod
+    def _extract_usage(msg) -> Dict[str, Any]:
+        """Extract token usage metadata from a LangChain AIMessage."""
+        usage = getattr(msg, 'usage_metadata', None)
+        return dict(usage) if usage else {}
+
+    def invoke(self, input_dict: Dict[str, str]) -> Tuple[str, Dict[str, Any]]:
+        """Process single image.
+
+        Returns:
+            Tuple of (processed text, token usage dict)
+        """
         if not self._chain:
             raise RuntimeError("langchain-google-genai not available")
 
         result = self._chain.invoke(input_dict)
-        return self._extract_text(result.content)
+        return self._extract_text(result.content), self._extract_usage(result)
 
-    def batch_invoke(self, input_dicts: List[Dict[str, str]]) -> List[str]:
-        """Process multiple images using LangChain batch processing."""
+    def batch_invoke(self, input_dicts: List[Dict[str, str]]) -> List[Tuple[str, Dict[str, Any]]]:
+        """Process multiple images using LangChain batch processing.
+
+        Returns:
+            List of (processed text, token usage dict) tuples
+        """
         if not self._chain:
             raise RuntimeError("langchain-google-genai not available")
 
@@ -136,7 +150,7 @@ class VertexAIVisionAgent:
 
         logger.info("Gemini batch processing complete")
 
-        return [self._extract_text(res[1].content) for res in sorted_results]
+        return [(self._extract_text(res[1].content), self._extract_usage(res[1])) for res in sorted_results]
 
 
 class VertexAIOCR(BaseOCR):
@@ -324,7 +338,7 @@ class VertexAIOCR(BaseOCR):
             batch_results = self._vision_agent.batch_invoke(input_dicts)
 
             results = []
-            for i, text_result in enumerate(batch_results):
+            for i, (text_result, token_usage) in enumerate(batch_results):
                 image_size = len(images[i])
                 results.append(
                     OCRResult(
@@ -344,6 +358,7 @@ class VertexAIOCR(BaseOCR):
                             "image_size_bytes": image_size,
                             "batch_index": i,
                             "content_type": kwargs.get("content_type"),
+                            "token_usage": token_usage,
                         },
                     )
                 )

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -36,8 +36,8 @@ class TestOCRMocked:
         mock_response = MagicMock()
         mock_response.content = "Mocked OCR text from image"
 
-        # Mock the agent's batch_invoke method
-        mock_agent.batch_invoke.return_value = ["Mocked OCR text from image"]
+        # Mock the agent's batch_invoke method (returns list of (text, usage) tuples)
+        mock_agent.batch_invoke.return_value = [("Mocked OCR text from image", {"input_tokens": 100, "output_tokens": 50, "total_tokens": 150})]
         mock_vision_agent.return_value = mock_agent
 
         # Test with a dummy image using batch_process_images


### PR DESCRIPTION
## Summary
- Extract token usage metadata (`input_tokens`, `output_tokens`, `total_tokens`) from LangChain AIMessage responses in both OpenAI and Vertex AI OCR providers
- Surface usage data in `OCRResult.metadata["token_usage"]` for programmatic access
- Document the feature in README.md

## Test plan
- [x] All 229 existing tests pass with no regressions
- [ ] Process an image with OpenAI OCR and verify `result.metadata["token_usage"]` contains token counts
- [ ] Process an image with Vertex AI OCR and verify the same

🤖 Generated with [Claude Code](https://claude.com/claude-code)