### PR TITLE
Fix/pdf heading heuristics

### DIFF
--- a/doc2mark/__init__.py
+++ b/doc2mark/__init__.py
@@ -21,6 +21,7 @@ from doc2mark.core.base import (
 # Main imports
 from doc2mark.core.loader import UnifiedDocumentLoader
 from doc2mark.ocr.base import OCRProvider, OCRConfig, OCRFactory
+from doc2mark.ocr.cache import OCRCache, MemoryOCRCache, NoOpOCRCache
 from doc2mark.core.table import TableStyle
 from doc2mark.core.chunker import Chunk, ChunkingConfig, chunk_content
 
@@ -38,6 +39,7 @@ __all__ = [
     'ProcessedDocument',
     'DocumentMetadata',
     'OCRConfig',
+    'OCRCache',
 
     # Exceptions
     'ProcessingError',
@@ -47,6 +49,10 @@ __all__ = [
 
     # Factory
     'OCRFactory',
+
+    # OCR cache
+    'MemoryOCRCache',
+    'NoOpOCRCache',
 
     # Chunking
     'Chunk',
@@ -69,6 +75,7 @@ def load(
         ocr_images=False,
         ocr_provider='openai',
         api_key=None,
+        ocr_cache=None,
         **kwargs
 ):
     """
@@ -85,6 +92,7 @@ def load(
             - False: Keep images as base64 data in output
         ocr_provider: OCR provider to use
         api_key: API key for OCR provider
+        ocr_cache: Optional request-scoped OCR cache handler
         **kwargs: Additional options
         
     Returns:
@@ -102,7 +110,8 @@ def load(
     """
     loader = UnifiedDocumentLoader(
         ocr_provider=ocr_provider,
-        api_key=api_key
+        api_key=api_key,
+        ocr_cache=ocr_cache
     )
     return loader.load(
         file_path,
@@ -120,6 +129,7 @@ def document_to_markdown(
         ocr_images=False,
         ocr_provider='openai',
         api_key=None,
+        ocr_cache=None,
         show_progress=True,
         **kwargs
 ):
@@ -137,6 +147,7 @@ def document_to_markdown(
             - False: Keep images as base64 data in output
         ocr_provider: OCR provider to use
         api_key: API key for OCR provider
+        ocr_cache: Optional request-scoped OCR cache handler
         show_progress: Whether to show progress messages
         **kwargs: Additional options
         
@@ -147,7 +158,8 @@ def document_to_markdown(
 
     loader = UnifiedDocumentLoader(
         ocr_provider=ocr_provider,
-        api_key=api_key
+        api_key=api_key,
+        ocr_cache=ocr_cache
     )
 
     # Process document
@@ -179,6 +191,7 @@ def batch_convert_to_markdown(
         recursive=True,
         ocr_provider='openai',
         api_key=None,
+        ocr_cache=None,
         show_progress=True,
         **kwargs
 ):
@@ -197,6 +210,7 @@ def batch_convert_to_markdown(
         recursive: Whether to process subdirectories
         ocr_provider: OCR provider to use
         api_key: API key for OCR provider
+        ocr_cache: Optional request-scoped OCR cache handler
         show_progress: Whether to show progress messages
         **kwargs: Additional options
         
@@ -205,7 +219,8 @@ def batch_convert_to_markdown(
     """
     loader = UnifiedDocumentLoader(
         ocr_provider=ocr_provider,
-        api_key=api_key
+        api_key=api_key,
+        ocr_cache=ocr_cache
     )
 
     return loader.batch_process(
@@ -230,6 +245,7 @@ def batch_process_documents(
         recursive=True,
         ocr_provider='openai',
         api_key=None,
+        ocr_cache=None,
         show_progress=True,
         save_files=True,
         **kwargs
@@ -250,6 +266,7 @@ def batch_process_documents(
         recursive: Whether to process subdirectories
         ocr_provider: OCR provider to use
         api_key: API key for OCR provider
+        ocr_cache: Optional request-scoped OCR cache handler
         show_progress: Whether to show progress messages
         save_files: Whether to save output files
         **kwargs: Additional options
@@ -259,7 +276,8 @@ def batch_process_documents(
     """
     loader = UnifiedDocumentLoader(
         ocr_provider=ocr_provider,
-        api_key=api_key
+        api_key=api_key,
+        ocr_cache=ocr_cache
     )
 
     return loader.batch_process(
@@ -283,6 +301,7 @@ def batch_process_files(
         ocr_images=False,
         ocr_provider='openai',
         api_key=None,
+        ocr_cache=None,
         show_progress=True,
         save_files=True,
         **kwargs
@@ -302,6 +321,7 @@ def batch_process_files(
             - False: Keep images as base64 data in output
         ocr_provider: OCR provider to use
         api_key: API key for OCR provider
+        ocr_cache: Optional request-scoped OCR cache handler
         show_progress: Whether to show progress messages
         save_files: Whether to save output files
         **kwargs: Additional options
@@ -321,7 +341,8 @@ def batch_process_files(
     """
     loader = UnifiedDocumentLoader(
         ocr_provider=ocr_provider,
-        api_key=api_key
+        api_key=api_key,
+        ocr_cache=ocr_cache
     )
 
     return loader.batch_process_files(

--- a/doc2mark/__init__.py
+++ b/doc2mark/__init__.py
@@ -21,7 +21,13 @@ from doc2mark.core.base import (
 # Main imports
 from doc2mark.core.loader import UnifiedDocumentLoader
 from doc2mark.ocr.base import OCRProvider, OCRConfig, OCRFactory
-from doc2mark.ocr.cache import OCRCache, MemoryOCRCache, NoOpOCRCache
+from doc2mark.ocr.cache import (
+    OCRCache,
+    MemoryOCRCache,
+    NoOpOCRCache,
+    RedisOCRCache,
+    create_ocr_cache,
+)
 from doc2mark.core.table import TableStyle
 from doc2mark.core.chunker import Chunk, ChunkingConfig, chunk_content
 
@@ -53,6 +59,8 @@ __all__ = [
     # OCR cache
     'MemoryOCRCache',
     'NoOpOCRCache',
+    'RedisOCRCache',
+    'create_ocr_cache',
 
     # Chunking
     'Chunk',

--- a/doc2mark/core/loader.py
+++ b/doc2mark/core/loader.py
@@ -15,6 +15,7 @@ from doc2mark.core.base import (
     UnsupportedFormatError
 )
 from doc2mark.ocr.base import BaseOCR, OCRConfig, OCRFactory, OCRProvider
+from doc2mark.ocr.cache import CachedOCR, OCRCache
 from doc2mark.ocr.prompts import PromptTemplate
 
 logger = logging.getLogger(__name__)
@@ -29,6 +30,7 @@ class UnifiedDocumentLoader:
             api_key: Optional[str] = None,
             ocr_config: Optional[OCRConfig] = None,
             cache_dir: Optional[str] = None,
+            ocr_cache: Optional[OCRCache] = None,
             # Enhanced OCR configuration for OpenAI / Vertex AI
             model: str = "gpt-4.1",
             temperature: float = 0,
@@ -57,6 +59,7 @@ class UnifiedDocumentLoader:
             api_key: API key for OCR provider (OpenAI defaults to OPENAI_API_KEY env var)
             ocr_config: Basic OCR configuration (from base class)
             cache_dir: Directory for caching processed documents
+            ocr_cache: Optional request-scoped OCR cache handler
 
             # Enhanced OpenAI OCR Configuration:
             model: OpenAI model to use (default: gpt-4.1)
@@ -162,6 +165,14 @@ class UnifiedDocumentLoader:
                     api_key=api_key,
                     config=ocr_config
                 )
+
+        self.ocr_cache = ocr_cache
+        if self.ocr_cache is not None:
+            if isinstance(self.ocr, CachedOCR):
+                self.ocr.cache = self.ocr_cache
+            else:
+                self.ocr = CachedOCR(self.ocr, self.ocr_cache)
+            logger.info(f"🧠 OCR cache enabled: {type(self.ocr_cache).__name__}")
 
         # Cache directory
         self.cache_dir = Path(cache_dir) if cache_dir else None
@@ -867,7 +878,8 @@ class UnifiedDocumentLoader:
             self,
             provider: Union[str, OCRProvider, BaseOCR],
             api_key: Optional[str] = None,
-            config: Optional[OCRConfig] = None
+            config: Optional[OCRConfig] = None,
+            ocr_cache: Optional[OCRCache] = None
     ):
         """Change OCR provider.
         
@@ -875,6 +887,7 @@ class UnifiedDocumentLoader:
             provider: New OCR provider
             api_key: API key for provider
             config: OCR configuration
+            ocr_cache: Optional OCR cache handler. Reuses existing handler when omitted.
         """
         if isinstance(provider, BaseOCR):
             self.ocr = provider
@@ -884,6 +897,17 @@ class UnifiedDocumentLoader:
                 api_key=api_key,
                 config=config
             )
+
+        if ocr_cache is not None:
+            self.ocr_cache = ocr_cache
+        elif not hasattr(self, "ocr_cache"):
+            self.ocr_cache = None
+
+        if self.ocr_cache is not None:
+            if isinstance(self.ocr, CachedOCR):
+                self.ocr.cache = self.ocr_cache
+            else:
+                self.ocr = CachedOCR(self.ocr, self.ocr_cache)
 
         # Reinitialize processors with new OCR
         self._initialize_processors()

--- a/doc2mark/core/loader.py
+++ b/doc2mark/core/loader.py
@@ -91,88 +91,27 @@ class UnifiedDocumentLoader:
         """
         logger.info("🚀 Initializing UnifiedDocumentLoader with enhanced OCR configuration")
 
-        # Initialize OCR with enhanced configuration
-        if isinstance(ocr_provider, BaseOCR):
-            self.ocr = ocr_provider
-            logger.info(f"✓ Using provided OCR instance: {type(ocr_provider).__name__}")
-        else:
-            logger.info(f"🤖 Initializing OCR provider: {ocr_provider}")
-
-            # For OpenAI provider, use enhanced configuration
-            if (isinstance(ocr_provider, str) and ocr_provider.lower() == 'openai') or \
-                    (isinstance(ocr_provider, OCRProvider) and ocr_provider == OCRProvider.OPENAI):
-
-                logger.info("🔧 Using enhanced OpenAI OCR configuration")
-
-                # Import OpenAI OCR specifically to use enhanced constructor
-                from doc2mark.ocr.openai import OpenAIOCR
-
-                self.ocr = OpenAIOCR(
-                    api_key=api_key,
-                    config=ocr_config,
-                    model=model,
-                    temperature=temperature,
-                    max_tokens=max_tokens,
-                    max_workers=max_workers,
-                    prompt_template=prompt_template,
-                    timeout=timeout,
-                    max_retries=max_retries,
-                    default_prompt=default_prompt,
-                    base_url=base_url,
-                    # Additional OpenAI parameters
-                    top_p=top_p,
-                    frequency_penalty=frequency_penalty,
-                    presence_penalty=presence_penalty
-                )
-
-                # Log the configuration being used
-                config_summary = self.ocr.get_configuration_summary()
-                logger.info("📋 OCR Configuration Summary:")
-                for key, value in config_summary.items():
-                    logger.info(f"   {key}: {value}")
-
-            elif (isinstance(ocr_provider, str) and ocr_provider.lower() == 'vertex_ai') or \
-                    (isinstance(ocr_provider, OCRProvider) and ocr_provider == OCRProvider.VERTEX_AI):
-
-                logger.info("Using enhanced Vertex AI OCR configuration")
-
-                from doc2mark.ocr.vertex_ai import VertexAIOCR
-
-                # Default to gemini-3.1-flash-lite-preview if user didn't change model from OpenAI default
-                vertex_model = model if model != "gpt-4.1" else "gemini-3.1-flash-lite-preview"
-
-                self.ocr = VertexAIOCR(
-                    config=ocr_config,
-                    project=project,
-                    location=location,
-                    model=vertex_model,
-                    temperature=temperature,
-                    max_tokens=max_tokens,
-                    prompt_template=prompt_template,
-                    default_prompt=default_prompt,
-                )
-
-                config_summary = self.ocr.get_configuration_summary()
-                logger.info("OCR Configuration Summary:")
-                for key, value in config_summary.items():
-                    logger.info(f"   {key}: {value}")
-
-            else:
-                # Use standard factory for other providers
-                logger.info(f"Using standard OCR factory for provider: {ocr_provider}")
-                self.ocr = OCRFactory.create(
-                    provider=ocr_provider,
-                    api_key=api_key,
-                    config=ocr_config
-                )
-
-        self.ocr_cache = ocr_cache
-        if self.ocr_cache is not None:
-            if isinstance(self.ocr, CachedOCR):
-                self.ocr.cache = self.ocr_cache
-            else:
-                self.ocr = CachedOCR(self.ocr, self.ocr_cache)
-            logger.info(f"🧠 OCR cache enabled: {type(self.ocr_cache).__name__}")
+        self.ocr_cache = None
+        self.ocr = self._create_ocr_provider(
+            ocr_provider=ocr_provider,
+            api_key=api_key,
+            ocr_config=ocr_config,
+            model=model,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            max_workers=max_workers,
+            prompt_template=prompt_template,
+            timeout=timeout,
+            max_retries=max_retries,
+            top_p=top_p,
+            frequency_penalty=frequency_penalty,
+            presence_penalty=presence_penalty,
+            base_url=base_url,
+            project=project,
+            location=location,
+            default_prompt=default_prompt,
+        )
+        self._apply_ocr_cache(ocr_cache)
 
         # Cache directory
         self.cache_dir = Path(cache_dir) if cache_dir else None
@@ -189,6 +128,147 @@ class UnifiedDocumentLoader:
         self._initialize_processors()
 
         logger.info("✅ UnifiedDocumentLoader initialized successfully")
+
+    @staticmethod
+    def _is_ocr_provider(provider: Union[str, OCRProvider], target: OCRProvider) -> bool:
+        if isinstance(provider, OCRProvider):
+            return provider == target
+        if isinstance(provider, str):
+            return provider.lower() == target.value
+        return False
+
+    @staticmethod
+    def _unwrap_ocr(ocr: BaseOCR) -> BaseOCR:
+        return ocr.wrapped if isinstance(ocr, CachedOCR) else ocr
+
+    def _create_ocr_provider(
+            self,
+            ocr_provider: Union[str, OCRProvider, BaseOCR],
+            api_key: Optional[str] = None,
+            ocr_config: Optional[OCRConfig] = None,
+            model: str = "gpt-4.1",
+            temperature: float = 0,
+            max_tokens: int = 4096,
+            max_workers: int = 5,
+            prompt_template: Union[str, PromptTemplate] = PromptTemplate.DEFAULT,
+            timeout: int = 30,
+            max_retries: int = 3,
+            top_p: float = 1.0,
+            frequency_penalty: float = 0.0,
+            presence_penalty: float = 0.0,
+            base_url: Optional[str] = None,
+            project: Optional[str] = None,
+            location: str = "global",
+            default_prompt: Optional[str] = None,
+            model_kwargs: Optional[Dict[str, Any]] = None,
+    ) -> BaseOCR:
+        """Create an OCR provider using the same enhanced path everywhere."""
+        if isinstance(ocr_provider, BaseOCR):
+            logger.info(f"✓ Using provided OCR instance: {type(ocr_provider).__name__}")
+            return ocr_provider
+
+        logger.info(f"🤖 Initializing OCR provider: {ocr_provider}")
+        extra_model_kwargs = dict(model_kwargs or {})
+
+        if self._is_ocr_provider(ocr_provider, OCRProvider.OPENAI):
+            logger.info("🔧 Using enhanced OpenAI OCR configuration")
+            from doc2mark.ocr.openai import OpenAIOCR
+
+            extra_model_kwargs.setdefault("top_p", top_p)
+            extra_model_kwargs.setdefault("frequency_penalty", frequency_penalty)
+            extra_model_kwargs.setdefault("presence_penalty", presence_penalty)
+
+            ocr = OpenAIOCR(
+                api_key=api_key,
+                config=ocr_config,
+                model=model,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                max_workers=max_workers,
+                prompt_template=prompt_template,
+                timeout=timeout,
+                max_retries=max_retries,
+                default_prompt=default_prompt,
+                base_url=base_url,
+                **extra_model_kwargs,
+            )
+            self._log_ocr_configuration(ocr, title="📋 OCR Configuration Summary:")
+            return ocr
+
+        if self._is_ocr_provider(ocr_provider, OCRProvider.VERTEX_AI):
+            logger.info("Using enhanced Vertex AI OCR configuration")
+            from doc2mark.ocr.vertex_ai import VertexAIOCR
+
+            vertex_model = model if model != "gpt-4.1" else "gemini-3.1-flash-lite-preview"
+            ocr = VertexAIOCR(
+                api_key=api_key,
+                config=ocr_config,
+                project=project,
+                location=location,
+                model=vertex_model,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                prompt_template=prompt_template,
+                default_prompt=default_prompt,
+                **extra_model_kwargs,
+            )
+            self._log_ocr_configuration(ocr, title="OCR Configuration Summary:")
+            return ocr
+
+        logger.info(f"Using standard OCR factory for provider: {ocr_provider}")
+        return OCRFactory.create(
+            provider=ocr_provider,
+            api_key=api_key,
+            config=ocr_config
+        )
+
+    @staticmethod
+    def _log_ocr_configuration(ocr: BaseOCR, title: str):
+        if hasattr(ocr, 'get_configuration_summary'):
+            config_summary = ocr.get_configuration_summary()
+            logger.info(title)
+            for key, value in config_summary.items():
+                logger.info(f"   {key}: {value}")
+
+    def _apply_ocr_cache(self, ocr_cache: Optional[OCRCache] = None):
+        """Apply an explicit cache, preserve embedded cache, or reuse loader cache."""
+        if ocr_cache is not None:
+            self.ocr_cache = ocr_cache
+            if isinstance(self.ocr, CachedOCR):
+                self.ocr.cache = ocr_cache
+            else:
+                self.ocr = CachedOCR(self.ocr, ocr_cache)
+            logger.info(f"🧠 OCR cache enabled: {type(self.ocr_cache).__name__}")
+            return
+
+        if isinstance(self.ocr, CachedOCR):
+            self.ocr_cache = self.ocr.cache
+            logger.info(f"🧠 OCR cache enabled: {type(self.ocr_cache).__name__}")
+            return
+
+        if self.ocr_cache is not None:
+            self.ocr = CachedOCR(self.ocr, self.ocr_cache)
+            logger.info(f"🧠 OCR cache enabled: {type(self.ocr_cache).__name__}")
+
+    def _current_ocr_constructor_options(self) -> Dict[str, Any]:
+        """Read current provider settings so set_ocr_provider does not downgrade OCR config."""
+        current = self._unwrap_ocr(self.ocr)
+        return {
+            "api_key": getattr(current, "api_key", None),
+            "ocr_config": getattr(current, "config", None),
+            "model": getattr(current, "model", "gpt-4.1"),
+            "temperature": getattr(current, "temperature", 0),
+            "max_tokens": getattr(current, "max_tokens", 4096),
+            "max_workers": getattr(current, "max_workers", 5),
+            "prompt_template": getattr(current, "prompt_template", PromptTemplate.DEFAULT),
+            "timeout": getattr(current, "timeout", 30),
+            "max_retries": getattr(current, "max_retries", 3),
+            "base_url": getattr(current, "base_url", None),
+            "project": getattr(current, "project", None),
+            "location": getattr(current, "location", "global"),
+            "default_prompt": getattr(current, "default_prompt", None),
+            "model_kwargs": dict(getattr(current, "model_kwargs", {}) or {}),
+        }
 
     def _initialize_processors(self):
         """Initialize all format processors."""
@@ -889,25 +969,23 @@ class UnifiedDocumentLoader:
             config: OCR configuration
             ocr_cache: Optional OCR cache handler. Reuses existing handler when omitted.
         """
+        preserved_options = self._current_ocr_constructor_options()
+        if api_key is not None:
+            preserved_options["api_key"] = api_key
+        if config is not None:
+            preserved_options["ocr_config"] = config
+
         if isinstance(provider, BaseOCR):
             self.ocr = provider
         else:
-            self.ocr = OCRFactory.create(
-                provider=provider,
-                api_key=api_key,
-                config=config
+            self.ocr = self._create_ocr_provider(
+                ocr_provider=provider,
+                **preserved_options,
             )
 
-        if ocr_cache is not None:
-            self.ocr_cache = ocr_cache
-        elif not hasattr(self, "ocr_cache"):
+        if not hasattr(self, "ocr_cache"):
             self.ocr_cache = None
-
-        if self.ocr_cache is not None:
-            if isinstance(self.ocr, CachedOCR):
-                self.ocr.cache = self.ocr_cache
-            else:
-                self.ocr = CachedOCR(self.ocr, self.ocr_cache)
+        self._apply_ocr_cache(ocr_cache)
 
         # Reinitialize processors with new OCR
         self._initialize_processors()

--- a/doc2mark/ocr/__init__.py
+++ b/doc2mark/ocr/__init__.py
@@ -7,7 +7,14 @@ from doc2mark.ocr.base import (
     BaseOCR,
     OCRFactory
 )
-from doc2mark.ocr.cache import OCRCache, MemoryOCRCache, NoOpOCRCache, CachedOCR
+from doc2mark.ocr.cache import (
+    OCRCache,
+    MemoryOCRCache,
+    NoOpOCRCache,
+    RedisOCRCache,
+    CachedOCR,
+    create_ocr_cache,
+)
 
 # Import and register providers
 from doc2mark.ocr.openai import OpenAIOCR, VisionAgent
@@ -38,7 +45,9 @@ __all__ = [
     # Cache
     'MemoryOCRCache',
     'NoOpOCRCache',
+    'RedisOCRCache',
     'CachedOCR',
+    'create_ocr_cache',
 
     # Providers
     'OpenAIOCR',

--- a/doc2mark/ocr/__init__.py
+++ b/doc2mark/ocr/__init__.py
@@ -7,6 +7,7 @@ from doc2mark.ocr.base import (
     BaseOCR,
     OCRFactory
 )
+from doc2mark.ocr.cache import OCRCache, MemoryOCRCache, NoOpOCRCache, CachedOCR
 
 # Import and register providers
 from doc2mark.ocr.openai import OpenAIOCR, VisionAgent
@@ -29,9 +30,15 @@ __all__ = [
 
     # Base classes
     'BaseOCR',
+    'OCRCache',
 
     # Factory
     'OCRFactory',
+
+    # Cache
+    'MemoryOCRCache',
+    'NoOpOCRCache',
+    'CachedOCR',
 
     # Providers
     'OpenAIOCR',

--- a/doc2mark/ocr/cache.py
+++ b/doc2mark/ocr/cache.py
@@ -5,6 +5,7 @@ import hashlib
 import json
 import logging
 import math
+import re
 import threading
 import time
 from abc import ABC, abstractmethod
@@ -18,11 +19,12 @@ from doc2mark.ocr.base import BaseOCR, OCRResult
 
 logger = logging.getLogger(__name__)
 
-CACHE_SCHEMA_VERSION = "ocr-cache-v2"
+CACHE_SCHEMA_VERSION = "ocr-cache-v3"
 OCR_CACHE_VALUE_SCHEMA_VERSION = "ocr-cache-value-v1"
 DEFAULT_REDIS_KEY_PREFIX = f"doc2mark:ocr:{CACHE_SCHEMA_VERSION}"
 
 _SENSITIVE_KEYS = {"api_key", "key", "secret", "password", "access_token", "refresh_token"}
+_ADDRESS_REPR_PATTERN = re.compile(r"\bat 0x[0-9a-fA-F]+\b|0x[0-9a-fA-F]+")
 _STAT_COUNTERS = (
     "hits",
     "misses",
@@ -54,7 +56,12 @@ def _normalize_result(result: Any) -> OCRResult:
     return OCRResult(text=str(result))
 
 
-def _stable_value(value: Any) -> Any:
+def _type_identity(value: Any) -> str:
+    cls = value.__class__
+    return f"{cls.__module__}.{cls.__qualname__}"
+
+
+def _stable_value(value: Any, *, strict: bool = False) -> Any:
     """Convert values into JSON-stable, non-secret cache key components."""
     if value is None or isinstance(value, (str, int, float, bool)):
         return value
@@ -66,20 +73,40 @@ def _stable_value(value: Any) -> Any:
     if isinstance(value, Enum):
         return value.value
     if is_dataclass(value) and not isinstance(value, type):
-        return _stable_value(asdict(value))
+        return _stable_value(asdict(value), strict=strict)
     if isinstance(value, dict):
         normalized = {}
         for key, item in value.items():
             key_str = str(key)
             if key_str.lower() in _SENSITIVE_KEYS:
                 continue
-            normalized[key_str] = _stable_value(item)
+            normalized[key_str] = _stable_value(item, strict=strict)
         return {key: normalized[key] for key in sorted(normalized)}
     if isinstance(value, set):
-        return sorted(_stable_value(item) for item in value)
+        return sorted(_stable_value(item, strict=strict) for item in value)
     if isinstance(value, (list, tuple)):
-        return [_stable_value(item) for item in value]
-    return repr(value)
+        return [_stable_value(item, strict=strict) for item in value]
+
+    repr_value = repr(value)
+    if _ADDRESS_REPR_PATTERN.search(repr_value):
+        if strict:
+            raise TypeError(
+                f"Cannot build a stable OCR cache key from {_type_identity(value)}; "
+                "provide JSON-stable model/config values instead."
+            )
+        return {"type": _type_identity(value)}
+    return {"type": _type_identity(value), "repr": repr_value}
+
+
+def _api_key_hash(provider: Any) -> Optional[str]:
+    api_key = getattr(provider, "api_key", None)
+    if not api_key:
+        return None
+    if isinstance(api_key, bytes):
+        api_key_bytes = api_key
+    else:
+        api_key_bytes = str(api_key).encode("utf-8")
+    return hashlib.sha256(api_key_bytes).hexdigest()
 
 
 def _prompt_hash(prompt: Any) -> Optional[str]:
@@ -100,17 +127,18 @@ def build_ocr_cache_key(
         "schema": cache_version,
         "image_sha256": hashlib.sha256(image).hexdigest(),
         "provider": f"{provider.__class__.__module__}.{provider.__class__.__qualname__}",
-        "config": _stable_value(getattr(provider, "config", None)),
-        "model": _stable_value(getattr(provider, "model", None)),
-        "temperature": _stable_value(getattr(provider, "temperature", None)),
-        "max_tokens": _stable_value(getattr(provider, "max_tokens", None)),
-        "prompt_template": _stable_value(getattr(provider, "prompt_template", None)),
+        "api_key_sha256": _api_key_hash(provider),
+        "config": _stable_value(getattr(provider, "config", None), strict=True),
+        "model": _stable_value(getattr(provider, "model", None), strict=True),
+        "temperature": _stable_value(getattr(provider, "temperature", None), strict=True),
+        "max_tokens": _stable_value(getattr(provider, "max_tokens", None), strict=True),
+        "prompt_template": _stable_value(getattr(provider, "prompt_template", None), strict=True),
         "default_prompt_sha256": _prompt_hash(getattr(provider, "default_prompt", None)),
-        "model_kwargs": _stable_value(getattr(provider, "model_kwargs", None)),
-        "base_url": _stable_value(getattr(provider, "base_url", None)),
-        "project": _stable_value(getattr(provider, "project", None)),
-        "location": _stable_value(getattr(provider, "location", None)),
-        "call_kwargs": _stable_value(kwargs or {}),
+        "model_kwargs": _stable_value(getattr(provider, "model_kwargs", None), strict=True),
+        "base_url": _stable_value(getattr(provider, "base_url", None), strict=True),
+        "project": _stable_value(getattr(provider, "project", None), strict=True),
+        "location": _stable_value(getattr(provider, "location", None), strict=True),
+        "call_kwargs": _stable_value(kwargs or {}, strict=True),
     }
     encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
     return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
@@ -770,7 +798,12 @@ class CachedOCR(BaseOCR):
         return getattr(self.wrapped, "requires_api_key", True)
 
     def __getattr__(self, name: str) -> Any:
-        return getattr(self.wrapped, name)
+        if name == "wrapped":
+            raise AttributeError(name)
+        wrapped = self.__dict__.get("wrapped")
+        if wrapped is None:
+            raise AttributeError(name)
+        return getattr(wrapped, name)
 
     def __setattr__(self, name: str, value: Any) -> None:
         if name in {"wrapped", "cache", "cache_version"} or name.startswith("_"):
@@ -829,6 +862,11 @@ class CachedOCR(BaseOCR):
         if miss_images:
             provider_results = self.wrapped.batch_process_images(miss_images, **kwargs)
             if len(provider_results) != len(miss_images):
+                for key, provider_result in zip(miss_keys, provider_results):
+                    normalized = _normalize_result(provider_result)
+                    self.cache.set(key, normalized)
+                    for position in miss_positions[key]:
+                        results[position] = _copy_result(normalized)
                 raise RuntimeError("OCR provider returned a different number of results than requested")
 
             for key, provider_result in zip(miss_keys, provider_results):

--- a/doc2mark/ocr/cache.py
+++ b/doc2mark/ocr/cache.py
@@ -1,0 +1,390 @@
+"""Request-scoped OCR cache helpers."""
+
+import copy
+import hashlib
+import json
+import threading
+import time
+from abc import ABC, abstractmethod
+from collections import OrderedDict
+from dataclasses import asdict, dataclass, is_dataclass
+from enum import Enum
+from typing import Any, Callable, Dict, List, Optional
+
+from doc2mark.ocr.base import BaseOCR, OCRResult
+
+
+CACHE_SCHEMA_VERSION = "ocr-cache-v1"
+_SENSITIVE_KEYS = {"api_key", "key", "secret", "password", "access_token", "refresh_token"}
+
+
+def _copy_result(result: OCRResult) -> OCRResult:
+    """Copy cached OCR results so callers cannot mutate shared cache state."""
+    return copy.deepcopy(result)
+
+
+def _normalize_result(result: Any) -> OCRResult:
+    if isinstance(result, OCRResult):
+        return result
+    if hasattr(result, "text"):
+        return OCRResult(
+            text=result.text,
+            confidence=getattr(result, "confidence", None),
+            language=getattr(result, "language", None),
+            metadata=getattr(result, "metadata", None),
+        )
+    return OCRResult(text=str(result))
+
+
+def _stable_value(value: Any) -> Any:
+    """Convert values into JSON-stable, non-secret cache key components."""
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, bytes):
+        return {
+            "bytes_sha256": hashlib.sha256(value).hexdigest(),
+            "length": len(value),
+        }
+    if isinstance(value, Enum):
+        return value.value
+    if is_dataclass(value) and not isinstance(value, type):
+        return _stable_value(asdict(value))
+    if isinstance(value, dict):
+        normalized = {}
+        for key, item in value.items():
+            key_str = str(key)
+            if key_str.lower() in _SENSITIVE_KEYS:
+                continue
+            normalized[key_str] = _stable_value(item)
+        return {key: normalized[key] for key in sorted(normalized)}
+    if isinstance(value, set):
+        return sorted(_stable_value(item) for item in value)
+    if isinstance(value, (list, tuple)):
+        return [_stable_value(item) for item in value]
+    return repr(value)
+
+
+def _prompt_hash(prompt: Any) -> Optional[str]:
+    if prompt is None:
+        return None
+    prompt_text = str(prompt)
+    return hashlib.sha256(prompt_text.encode("utf-8")).hexdigest()
+
+
+def build_ocr_cache_key(
+    provider: Any,
+    image: bytes,
+    kwargs: Optional[Dict[str, Any]] = None,
+    cache_version: str = CACHE_SCHEMA_VERSION,
+) -> str:
+    """Build a stable cache key for an OCR request."""
+    payload = {
+        "schema": cache_version,
+        "image_sha256": hashlib.sha256(image).hexdigest(),
+        "provider": f"{provider.__class__.__module__}.{provider.__class__.__qualname__}",
+        "config": _stable_value(getattr(provider, "config", None)),
+        "model": _stable_value(getattr(provider, "model", None)),
+        "temperature": _stable_value(getattr(provider, "temperature", None)),
+        "max_tokens": _stable_value(getattr(provider, "max_tokens", None)),
+        "prompt_template": _stable_value(getattr(provider, "prompt_template", None)),
+        "default_prompt_sha256": _prompt_hash(getattr(provider, "default_prompt", None)),
+        "model_kwargs": _stable_value(getattr(provider, "model_kwargs", None)),
+        "call_kwargs": _stable_value(kwargs or {}),
+    }
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+class OCRCache(ABC):
+    """Interface for OCR result caches."""
+
+    @abstractmethod
+    def get(self, key: str) -> Optional[OCRResult]:
+        """Return a cached OCR result, or None on miss."""
+
+    @abstractmethod
+    def set(self, key: str, result: OCRResult, ttl_seconds: Optional[float] = None) -> None:
+        """Store an OCR result."""
+
+    @abstractmethod
+    def cleanup(self) -> int:
+        """Remove expired entries and return the number removed."""
+
+    @abstractmethod
+    def clear(self) -> None:
+        """Clear all cached entries."""
+
+    @abstractmethod
+    def stats(self) -> Dict[str, Any]:
+        """Return cache statistics."""
+
+
+@dataclass
+class _MemoryCacheEntry:
+    result: OCRResult
+    created_at: float
+    expires_at: float
+    hits: int = 0
+
+
+class MemoryOCRCache(OCRCache):
+    """Thread-safe in-memory OCR cache with TTL and max-age bounds."""
+
+    def __init__(
+        self,
+        ttl_seconds: float = 3600,
+        max_age_seconds: Optional[float] = 43200,
+        max_entries: int = 1024,
+        time_func: Optional[Callable[[], float]] = None,
+    ):
+        if ttl_seconds <= 0:
+            raise ValueError("ttl_seconds must be positive")
+        if max_age_seconds is not None and max_age_seconds <= 0:
+            raise ValueError("max_age_seconds must be positive or None")
+        if max_entries <= 0:
+            raise ValueError("max_entries must be positive")
+
+        self.ttl_seconds = ttl_seconds
+        self.max_age_seconds = max_age_seconds
+        self.max_entries = max_entries
+        self._time = time_func or time.time
+        self._entries: "OrderedDict[str, _MemoryCacheEntry]" = OrderedDict()
+        self._lock = threading.RLock()
+        self._stats = {
+            "hits": 0,
+            "misses": 0,
+            "sets": 0,
+            "evictions": 0,
+            "expired": 0,
+        }
+
+    def get(self, key: str) -> Optional[OCRResult]:
+        now = self._time()
+        with self._lock:
+            entry = self._entries.get(key)
+            if entry is None:
+                self._stats["misses"] += 1
+                return None
+
+            if self._is_expired(entry, now):
+                del self._entries[key]
+                self._stats["expired"] += 1
+                self._stats["misses"] += 1
+                return None
+
+            entry.hits += 1
+            self._stats["hits"] += 1
+            entry.expires_at = self._refreshed_expiry(entry, now)
+            self._entries.move_to_end(key)
+            return _copy_result(entry.result)
+
+    def set(self, key: str, result: OCRResult, ttl_seconds: Optional[float] = None) -> None:
+        now = self._time()
+        ttl = ttl_seconds if ttl_seconds is not None else self.ttl_seconds
+        if ttl <= 0:
+            raise ValueError("ttl_seconds must be positive")
+
+        with self._lock:
+            self.cleanup()
+            expires_at = now + ttl
+            if self.max_age_seconds is not None:
+                expires_at = min(expires_at, now + self.max_age_seconds)
+
+            self._entries[key] = _MemoryCacheEntry(
+                result=_copy_result(_normalize_result(result)),
+                created_at=now,
+                expires_at=expires_at,
+            )
+            self._entries.move_to_end(key)
+            self._stats["sets"] += 1
+            self._evict_over_limit()
+
+    def cleanup(self) -> int:
+        now = self._time()
+        removed = 0
+        with self._lock:
+            expired_keys = [
+                key for key, entry in self._entries.items()
+                if self._is_expired(entry, now)
+            ]
+            for key in expired_keys:
+                del self._entries[key]
+                removed += 1
+            if removed:
+                self._stats["expired"] += removed
+        return removed
+
+    def clear(self) -> None:
+        with self._lock:
+            self._entries.clear()
+
+    def stats(self) -> Dict[str, Any]:
+        with self._lock:
+            stats = dict(self._stats)
+            stats.update({
+                "entries": len(self._entries),
+                "max_entries": self.max_entries,
+                "ttl_seconds": self.ttl_seconds,
+                "max_age_seconds": self.max_age_seconds,
+            })
+            return stats
+
+    def _is_expired(self, entry: _MemoryCacheEntry, now: float) -> bool:
+        if now >= entry.expires_at:
+            return True
+        if self.max_age_seconds is not None and now >= entry.created_at + self.max_age_seconds:
+            return True
+        return False
+
+    def _refreshed_expiry(self, entry: _MemoryCacheEntry, now: float) -> float:
+        expires_at = now + self.ttl_seconds
+        if self.max_age_seconds is not None:
+            expires_at = min(expires_at, entry.created_at + self.max_age_seconds)
+        return expires_at
+
+    def _evict_over_limit(self) -> None:
+        while len(self._entries) > self.max_entries:
+            self._entries.popitem(last=False)
+            self._stats["evictions"] += 1
+
+
+class NoOpOCRCache(OCRCache):
+    """Cache implementation that always misses."""
+
+    def get(self, key: str) -> Optional[OCRResult]:
+        return None
+
+    def set(self, key: str, result: OCRResult, ttl_seconds: Optional[float] = None) -> None:
+        return None
+
+    def cleanup(self) -> int:
+        return 0
+
+    def clear(self) -> None:
+        return None
+
+    def stats(self) -> Dict[str, Any]:
+        return {
+            "hits": 0,
+            "misses": 0,
+            "sets": 0,
+            "evictions": 0,
+            "expired": 0,
+            "entries": 0,
+            "max_entries": 0,
+        }
+
+
+class CachedOCR(BaseOCR):
+    """OCR provider wrapper that checks a cache before calling the provider."""
+
+    def __init__(
+        self,
+        wrapped: BaseOCR,
+        cache: Optional[OCRCache],
+        cache_version: str = CACHE_SCHEMA_VERSION,
+    ):
+        object.__setattr__(self, "wrapped", wrapped)
+        object.__setattr__(self, "cache", cache or NoOpOCRCache())
+        object.__setattr__(self, "cache_version", cache_version)
+
+    @property
+    def api_key(self) -> Optional[str]:
+        return getattr(self.wrapped, "api_key", None)
+
+    @api_key.setter
+    def api_key(self, value: Optional[str]) -> None:
+        setattr(self.wrapped, "api_key", value)
+
+    @property
+    def config(self) -> Any:
+        return getattr(self.wrapped, "config", None)
+
+    @config.setter
+    def config(self, value: Any) -> None:
+        setattr(self.wrapped, "config", value)
+
+    @property
+    def provider_name(self) -> str:
+        return getattr(self.wrapped, "provider_name", type(self.wrapped).__name__)
+
+    @property
+    def requires_api_key(self) -> bool:
+        return getattr(self.wrapped, "requires_api_key", True)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self.wrapped, name)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        if name in {"wrapped", "cache", "cache_version"} or name.startswith("_"):
+            object.__setattr__(self, name, value)
+        elif hasattr(self.wrapped, name):
+            setattr(self.wrapped, name, value)
+        else:
+            object.__setattr__(self, name, value)
+
+    def validate_api_key(self) -> bool:
+        return self.wrapped.validate_api_key()
+
+    def get_configuration_summary(self) -> Dict[str, Any]:
+        if hasattr(self.wrapped, "get_configuration_summary"):
+            return self.wrapped.get_configuration_summary()
+        return {
+            "provider": type(self.wrapped).__name__,
+            "api_key_configured": bool(getattr(self.wrapped, "api_key", None)),
+            "config": _stable_value(getattr(self.wrapped, "config", None)),
+        }
+
+    def preprocess_image(self, image_data: bytes) -> bytes:
+        return self.wrapped.preprocess_image(image_data)
+
+    def process_image(self, image: bytes, **kwargs) -> OCRResult:
+        results = self.batch_process_images([image], **kwargs)
+        return results[0] if results else OCRResult(text="")
+
+    def batch_process_images(self, images: List[bytes], **kwargs) -> List[OCRResult]:
+        if not images:
+            return []
+
+        results: List[Optional[OCRResult]] = [None] * len(images)
+        miss_images: List[bytes] = []
+        miss_keys: List[str] = []
+        miss_positions: Dict[str, List[int]] = {}
+
+        for index, image in enumerate(images):
+            key = build_ocr_cache_key(
+                self.wrapped,
+                image,
+                kwargs=kwargs,
+                cache_version=self.cache_version,
+            )
+            cached = self.cache.get(key)
+            if cached is not None:
+                results[index] = cached
+                continue
+
+            if key not in miss_positions:
+                miss_positions[key] = []
+                miss_keys.append(key)
+                miss_images.append(image)
+            miss_positions[key].append(index)
+
+        if miss_images:
+            provider_results = self.wrapped.batch_process_images(miss_images, **kwargs)
+            if len(provider_results) != len(miss_images):
+                raise RuntimeError(
+                    "OCR provider returned a different number of results than requested"
+                )
+
+            for key, provider_result in zip(miss_keys, provider_results):
+                normalized = _normalize_result(provider_result)
+                self.cache.set(key, normalized)
+                for position in miss_positions[key]:
+                    results[position] = _copy_result(normalized)
+
+        final_results: List[OCRResult] = []
+        for result in results:
+            if result is None:
+                raise RuntimeError("OCR cache wrapper failed to populate all OCR results")
+            final_results.append(_copy_result(result))
+        return final_results

--- a/doc2mark/ocr/cache.py
+++ b/doc2mark/ocr/cache.py
@@ -1,21 +1,39 @@
-"""Request-scoped OCR cache helpers."""
+"""OCR cache helpers."""
 
 import copy
 import hashlib
 import json
+import logging
+import math
 import threading
 import time
 from abc import ABC, abstractmethod
 from collections import OrderedDict
 from dataclasses import asdict, dataclass, is_dataclass
 from enum import Enum
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from doc2mark.ocr.base import BaseOCR, OCRResult
 
 
-CACHE_SCHEMA_VERSION = "ocr-cache-v1"
+logger = logging.getLogger(__name__)
+
+CACHE_SCHEMA_VERSION = "ocr-cache-v2"
+OCR_CACHE_VALUE_SCHEMA_VERSION = "ocr-cache-value-v1"
+DEFAULT_REDIS_KEY_PREFIX = f"doc2mark:ocr:{CACHE_SCHEMA_VERSION}"
+
 _SENSITIVE_KEYS = {"api_key", "key", "secret", "password", "access_token", "refresh_token"}
+_STAT_COUNTERS = (
+    "hits",
+    "misses",
+    "sets",
+    "refreshes",
+    "refresh_skipped",
+    "expired",
+    "evictions",
+    "deletes",
+    "errors",
+)
 
 
 def _copy_result(result: OCRResult) -> OCRResult:
@@ -89,10 +107,131 @@ def build_ocr_cache_key(
         "prompt_template": _stable_value(getattr(provider, "prompt_template", None)),
         "default_prompt_sha256": _prompt_hash(getattr(provider, "default_prompt", None)),
         "model_kwargs": _stable_value(getattr(provider, "model_kwargs", None)),
+        "base_url": _stable_value(getattr(provider, "base_url", None)),
+        "project": _stable_value(getattr(provider, "project", None)),
+        "location": _stable_value(getattr(provider, "location", None)),
         "call_kwargs": _stable_value(kwargs or {}),
     }
     encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
     return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+@dataclass
+class _SerializedCacheEntry:
+    result: OCRResult
+    created_at: float
+    expires_at: float
+    refresh_count: int = 0
+
+
+def _serialize_ocr_cache_entry(
+    result: OCRResult,
+    *,
+    created_at: float,
+    expires_at: float,
+    refresh_count: int = 0,
+) -> str:
+    """Serialize an OCR cache value without request source data or secrets."""
+    normalized = _normalize_result(result)
+    payload = {
+        "schema": OCR_CACHE_VALUE_SCHEMA_VERSION,
+        "result": {
+            "text": normalized.text,
+            "confidence": normalized.confidence,
+            "language": normalized.language,
+            "metadata": _stable_value(normalized.metadata),
+        },
+        "created_at": float(created_at),
+        "expires_at": float(expires_at),
+        "refresh_count": int(refresh_count),
+    }
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def _deserialize_ocr_cache_entry(payload: Any) -> _SerializedCacheEntry:
+    """Deserialize an OCR cache value and validate its private value schema."""
+    if isinstance(payload, bytes):
+        try:
+            payload = payload.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise ValueError("Malformed OCR cache value") from exc
+    if isinstance(payload, str):
+        try:
+            payload = json.loads(payload)
+        except json.JSONDecodeError as exc:
+            raise ValueError("Malformed OCR cache value") from exc
+    if not isinstance(payload, dict):
+        raise ValueError("Malformed OCR cache value")
+    if payload.get("schema") != OCR_CACHE_VALUE_SCHEMA_VERSION:
+        raise ValueError("Unsupported OCR cache value schema")
+
+    result_payload = payload.get("result")
+    if not isinstance(result_payload, dict) or "text" not in result_payload:
+        raise ValueError("Malformed OCR cache result")
+
+    try:
+        created_at = float(payload["created_at"])
+        expires_at = float(payload["expires_at"])
+        refresh_count = int(payload.get("refresh_count", 0))
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ValueError("Malformed OCR cache metadata") from exc
+
+    return _SerializedCacheEntry(
+        result=OCRResult(
+            text=str(result_payload["text"]),
+            confidence=result_payload.get("confidence"),
+            language=result_payload.get("language"),
+            metadata=result_payload.get("metadata"),
+        ),
+        created_at=created_at,
+        expires_at=expires_at,
+        refresh_count=refresh_count,
+    )
+
+
+def _new_stats() -> Dict[str, int]:
+    return {key: 0 for key in _STAT_COUNTERS}
+
+
+def _validate_cache_bounds(
+    ttl_seconds: float,
+    max_age_seconds: Optional[float],
+    max_refreshes: Optional[int],
+) -> None:
+    if ttl_seconds <= 0:
+        raise ValueError("ttl_seconds must be positive")
+    if max_age_seconds is not None and max_age_seconds <= 0:
+        raise ValueError("max_age_seconds must be positive or None")
+    if max_refreshes is not None and max_refreshes < 0:
+        raise ValueError("max_refreshes must be non-negative or None")
+
+
+def _is_entry_expired(entry: Any, now: float, max_age_seconds: Optional[float]) -> bool:
+    if now >= entry.expires_at:
+        return True
+    if max_age_seconds is not None and now >= entry.created_at + max_age_seconds:
+        return True
+    return False
+
+
+def _can_refresh(entry: Any, max_refreshes: Optional[int]) -> bool:
+    return max_refreshes is None or entry.refresh_count < max_refreshes
+
+
+def _refreshed_expiry(
+    entry: Any,
+    now: float,
+    ttl_seconds: float,
+    max_age_seconds: Optional[float],
+) -> float:
+    expires_at = now + ttl_seconds
+    if max_age_seconds is not None:
+        expires_at = min(expires_at, entry.created_at + max_age_seconds)
+    return expires_at
+
+
+def _redis_expires_in(expires_at: float, now: float) -> int:
+    return max(1, int(math.ceil(expires_at - now)))
 
 
 class OCRCache(ABC):
@@ -125,38 +264,32 @@ class _MemoryCacheEntry:
     created_at: float
     expires_at: float
     hits: int = 0
+    refresh_count: int = 0
 
 
 class MemoryOCRCache(OCRCache):
-    """Thread-safe in-memory OCR cache with TTL and max-age bounds."""
+    """Thread-safe in-memory OCR cache with TTL, max-age, and refresh bounds."""
 
     def __init__(
         self,
         ttl_seconds: float = 3600,
         max_age_seconds: Optional[float] = 43200,
         max_entries: int = 1024,
+        max_refreshes: Optional[int] = 10,
         time_func: Optional[Callable[[], float]] = None,
     ):
-        if ttl_seconds <= 0:
-            raise ValueError("ttl_seconds must be positive")
-        if max_age_seconds is not None and max_age_seconds <= 0:
-            raise ValueError("max_age_seconds must be positive or None")
+        _validate_cache_bounds(ttl_seconds, max_age_seconds, max_refreshes)
         if max_entries <= 0:
             raise ValueError("max_entries must be positive")
 
         self.ttl_seconds = ttl_seconds
         self.max_age_seconds = max_age_seconds
         self.max_entries = max_entries
+        self.max_refreshes = max_refreshes
         self._time = time_func or time.time
         self._entries: "OrderedDict[str, _MemoryCacheEntry]" = OrderedDict()
         self._lock = threading.RLock()
-        self._stats = {
-            "hits": 0,
-            "misses": 0,
-            "sets": 0,
-            "evictions": 0,
-            "expired": 0,
-        }
+        self._stats = _new_stats()
 
     def get(self, key: str) -> Optional[OCRResult]:
         now = self._time()
@@ -170,11 +303,17 @@ class MemoryOCRCache(OCRCache):
                 del self._entries[key]
                 self._stats["expired"] += 1
                 self._stats["misses"] += 1
+                self._stats["deletes"] += 1
                 return None
 
             entry.hits += 1
             self._stats["hits"] += 1
-            entry.expires_at = self._refreshed_expiry(entry, now)
+            if _can_refresh(entry, self.max_refreshes):
+                entry.refresh_count += 1
+                entry.expires_at = self._refreshed_expiry(entry, now)
+                self._stats["refreshes"] += 1
+            else:
+                self._stats["refresh_skipped"] += 1
             self._entries.move_to_end(key)
             return _copy_result(entry.result)
 
@@ -203,44 +342,41 @@ class MemoryOCRCache(OCRCache):
         now = self._time()
         removed = 0
         with self._lock:
-            expired_keys = [
-                key for key, entry in self._entries.items()
-                if self._is_expired(entry, now)
-            ]
+            expired_keys = [key for key, entry in self._entries.items() if self._is_expired(entry, now)]
             for key in expired_keys:
                 del self._entries[key]
                 removed += 1
             if removed:
                 self._stats["expired"] += removed
+                self._stats["deletes"] += removed
         return removed
 
     def clear(self) -> None:
         with self._lock:
+            removed = len(self._entries)
             self._entries.clear()
+            self._stats["deletes"] += removed
 
     def stats(self) -> Dict[str, Any]:
         with self._lock:
             stats = dict(self._stats)
-            stats.update({
-                "entries": len(self._entries),
-                "max_entries": self.max_entries,
-                "ttl_seconds": self.ttl_seconds,
-                "max_age_seconds": self.max_age_seconds,
-            })
+            stats.update(
+                {
+                    "backend": "memory",
+                    "entries": len(self._entries),
+                    "max_entries": self.max_entries,
+                    "ttl_seconds": self.ttl_seconds,
+                    "max_age_seconds": self.max_age_seconds,
+                    "max_refreshes": self.max_refreshes,
+                }
+            )
             return stats
 
     def _is_expired(self, entry: _MemoryCacheEntry, now: float) -> bool:
-        if now >= entry.expires_at:
-            return True
-        if self.max_age_seconds is not None and now >= entry.created_at + self.max_age_seconds:
-            return True
-        return False
+        return _is_entry_expired(entry, now, self.max_age_seconds)
 
     def _refreshed_expiry(self, entry: _MemoryCacheEntry, now: float) -> float:
-        expires_at = now + self.ttl_seconds
-        if self.max_age_seconds is not None:
-            expires_at = min(expires_at, entry.created_at + self.max_age_seconds)
-        return expires_at
+        return _refreshed_expiry(entry, now, self.ttl_seconds, self.max_age_seconds)
 
     def _evict_over_limit(self) -> None:
         while len(self._entries) > self.max_entries:
@@ -264,15 +400,336 @@ class NoOpOCRCache(OCRCache):
         return None
 
     def stats(self) -> Dict[str, Any]:
-        return {
-            "hits": 0,
-            "misses": 0,
-            "sets": 0,
-            "evictions": 0,
-            "expired": 0,
-            "entries": 0,
-            "max_entries": 0,
-        }
+        stats: Dict[str, Any] = _new_stats()
+        stats.update(
+            {
+                "backend": "noop",
+                "entries": 0,
+                "max_entries": 0,
+                "ttl_seconds": None,
+                "max_age_seconds": None,
+                "max_refreshes": None,
+            }
+        )
+        return stats
+
+
+class RedisOCRCache(OCRCache):
+    """Redis-backed OCR cache.
+
+    Redis is imported lazily so doc2mark remains importable without the
+    optional redis extra. The constructor verifies the connection with ping().
+    """
+
+    def __init__(
+        self,
+        redis_url: str,
+        ttl_seconds: float = 3600,
+        max_age_seconds: Optional[float] = 43200,
+        max_refreshes: Optional[int] = 10,
+        key_prefix: str = DEFAULT_REDIS_KEY_PREFIX,
+        time_func: Optional[Callable[[], float]] = None,
+    ):
+        if not redis_url:
+            raise ValueError("redis_url is required")
+        _validate_cache_bounds(ttl_seconds, max_age_seconds, max_refreshes)
+
+        try:
+            import redis
+        except ImportError as exc:
+            raise ImportError("RedisOCRCache requires the 'redis' optional dependency") from exc
+
+        self.redis_url = redis_url
+        self.ttl_seconds = ttl_seconds
+        self.max_age_seconds = max_age_seconds
+        self.max_refreshes = max_refreshes
+        self.key_prefix = key_prefix.rstrip(":")
+        self._time = time_func or time.time
+        self._redis = redis.from_url(redis_url)
+        self._redis.ping()
+        self._watch_error = self._resolve_watch_error(redis)
+        self._lock = threading.RLock()
+        self._stats = _new_stats()
+
+    def get(self, key: str) -> Optional[OCRResult]:
+        redis_key = self._redis_key(key)
+        try:
+            value = self._redis.get(redis_key)
+        except Exception:
+            self._increment("errors")
+            return None
+
+        if value is None:
+            self._increment("misses")
+            return None
+
+        try:
+            entry = _deserialize_ocr_cache_entry(value)
+        except ValueError:
+            self._increment("misses")
+            self._delete_key(redis_key)
+            return None
+
+        now = self._time()
+        if self._is_expired(entry, now):
+            self._increment("misses")
+            self._increment("expired")
+            self._delete_key(redis_key)
+            return None
+
+        result = _copy_result(entry.result)
+        self._increment("hits")
+        if _can_refresh(entry, self.max_refreshes):
+            try:
+                refreshed = self._refresh_key(redis_key, entry, now)
+            except Exception:
+                self._increment("errors")
+            else:
+                self._increment("refreshes" if refreshed else "refresh_skipped")
+        else:
+            self._increment("refresh_skipped")
+        return result
+
+    def set(self, key: str, result: OCRResult, ttl_seconds: Optional[float] = None) -> None:
+        now = self._time()
+        ttl = ttl_seconds if ttl_seconds is not None else self.ttl_seconds
+        if ttl <= 0:
+            raise ValueError("ttl_seconds must be positive")
+
+        expires_at = now + ttl
+        if self.max_age_seconds is not None:
+            expires_at = min(expires_at, now + self.max_age_seconds)
+        value = _serialize_ocr_cache_entry(
+            result,
+            created_at=now,
+            expires_at=expires_at,
+            refresh_count=0,
+        )
+
+        try:
+            self._redis.set(self._redis_key(key), value, ex=_redis_expires_in(expires_at, now))
+        except Exception:
+            self._increment("errors")
+            return
+        self._increment("sets")
+
+    def cleanup(self) -> int:
+        return 0
+
+    def clear(self) -> None:
+        pattern = f"{self.key_prefix}:*"
+        cursor: Any = 0
+        deleted = 0
+        try:
+            while True:
+                cursor, keys = self._redis.scan(cursor=cursor, match=pattern, count=1000)
+                if keys:
+                    deleted += int(self._redis.delete(*keys) or 0)
+                if cursor in (0, "0", b"0"):
+                    break
+        except Exception:
+            self._increment("errors")
+            return None
+        if deleted:
+            self._increment("deletes", deleted)
+        return None
+
+    def stats(self) -> Dict[str, Any]:
+        with self._lock:
+            stats = dict(self._stats)
+        stats.update(
+            {
+                "backend": "redis",
+                "entries": None,
+                "max_entries": None,
+                "ttl_seconds": self.ttl_seconds,
+                "max_age_seconds": self.max_age_seconds,
+                "max_refreshes": self.max_refreshes,
+                "key_prefix": self.key_prefix,
+            }
+        )
+        return stats
+
+    def _redis_key(self, key: str) -> str:
+        return f"{self.key_prefix}:{key}"
+
+    def _is_expired(self, entry: _SerializedCacheEntry, now: float) -> bool:
+        return _is_entry_expired(entry, now, self.max_age_seconds)
+
+    def _refresh_key(self, redis_key: str, entry: _SerializedCacheEntry, now: float) -> bool:
+        if not hasattr(self._redis, "pipeline"):
+            current_value = self._redis.get(redis_key)
+            if current_value is None:
+                return False
+            try:
+                current_entry = _deserialize_ocr_cache_entry(current_value)
+            except ValueError:
+                return False
+            if self._is_expired(current_entry, now) or not _can_refresh(current_entry, self.max_refreshes):
+                return False
+            value, redis_ttl = self._refreshed_value(current_entry, now)
+            self._redis.set(redis_key, value, ex=redis_ttl)
+            return True
+
+        pipe = self._redis.pipeline()
+        if hasattr(pipe, "__enter__"):
+            with pipe as active_pipe:
+                return self._refresh_with_pipeline(active_pipe, redis_key, now)
+        try:
+            return self._refresh_with_pipeline(pipe, redis_key, now)
+        finally:
+            if hasattr(pipe, "reset"):
+                pipe.reset()
+
+    def _refresh_with_pipeline(self, pipe: Any, redis_key: str, now: float) -> bool:
+        try:
+            if hasattr(pipe, "watch"):
+                pipe.watch(redis_key)
+            current_value = pipe.get(redis_key) if hasattr(pipe, "get") else self._redis.get(redis_key)
+            if current_value is None:
+                if hasattr(pipe, "unwatch"):
+                    pipe.unwatch()
+                return False
+            try:
+                current_entry = _deserialize_ocr_cache_entry(current_value)
+            except ValueError:
+                if hasattr(pipe, "unwatch"):
+                    pipe.unwatch()
+                return False
+            if self._is_expired(current_entry, now) or not _can_refresh(current_entry, self.max_refreshes):
+                if hasattr(pipe, "unwatch"):
+                    pipe.unwatch()
+                return False
+            value, redis_ttl = self._refreshed_value(current_entry, now)
+            if hasattr(pipe, "multi"):
+                pipe.multi()
+            pipe.set(redis_key, value, ex=redis_ttl)
+            if hasattr(pipe, "execute"):
+                pipe.execute()
+            return True
+        except Exception as exc:
+            if self._watch_error is not None and isinstance(exc, self._watch_error):
+                return False
+            raise
+        finally:
+            if hasattr(pipe, "reset"):
+                pipe.reset()
+
+    def _refreshed_value(self, entry: _SerializedCacheEntry, now: float) -> Tuple[str, int]:
+        refreshed = _SerializedCacheEntry(
+            result=entry.result,
+            created_at=entry.created_at,
+            expires_at=_refreshed_expiry(entry, now, self.ttl_seconds, self.max_age_seconds),
+            refresh_count=entry.refresh_count + 1,
+        )
+        value = _serialize_ocr_cache_entry(
+            refreshed.result,
+            created_at=refreshed.created_at,
+            expires_at=refreshed.expires_at,
+            refresh_count=refreshed.refresh_count,
+        )
+        return value, _redis_expires_in(refreshed.expires_at, now)
+
+    def _delete_key(self, redis_key: str) -> int:
+        try:
+            deleted = int(self._redis.delete(redis_key) or 0)
+        except Exception:
+            self._increment("errors")
+            return 0
+        if deleted:
+            self._increment("deletes", deleted)
+        return deleted
+
+    def _increment(self, key: str, amount: int = 1) -> None:
+        with self._lock:
+            self._stats[key] += amount
+
+    @staticmethod
+    def _resolve_watch_error(redis_module: Any) -> Optional[type]:
+        watch_error = getattr(redis_module, "WatchError", None)
+        if watch_error is not None:
+            return watch_error
+        exceptions = getattr(redis_module, "exceptions", None)
+        if exceptions is not None:
+            return getattr(exceptions, "WatchError", None)
+        return None
+
+
+def create_ocr_cache(
+    provider: Optional[str] = "none",
+    *,
+    redis_url: Optional[str] = None,
+    fallback: str = "memory",
+    ttl_seconds: float = 3600,
+    max_age_seconds: Optional[float] = 43200,
+    max_refreshes: Optional[int] = 10,
+    max_entries: int = 1024,
+    key_prefix: str = DEFAULT_REDIS_KEY_PREFIX,
+) -> Optional[OCRCache]:
+    """Create an OCR cache backend from a small provider name."""
+    normalized = _normalize_cache_provider(provider)
+    if normalized in {"none", "off", "false", "disabled", ""}:
+        return None
+    if normalized in {"noop", "no-op"}:
+        return NoOpOCRCache()
+    if normalized in {"memory", "in-memory", "in_memory"}:
+        return MemoryOCRCache(
+            ttl_seconds=ttl_seconds,
+            max_age_seconds=max_age_seconds,
+            max_entries=max_entries,
+            max_refreshes=max_refreshes,
+        )
+    if normalized == "redis":
+        try:
+            return RedisOCRCache(
+                redis_url=redis_url or "",
+                ttl_seconds=ttl_seconds,
+                max_age_seconds=max_age_seconds,
+                max_refreshes=max_refreshes,
+                key_prefix=key_prefix,
+            )
+        except Exception as exc:
+            return _fallback_cache(
+                exc,
+                fallback=fallback,
+                ttl_seconds=ttl_seconds,
+                max_age_seconds=max_age_seconds,
+                max_refreshes=max_refreshes,
+                max_entries=max_entries,
+            )
+    raise ValueError(f"Unknown OCR cache provider: {provider}")
+
+
+def _normalize_cache_provider(provider: Optional[str]) -> str:
+    if provider is None:
+        return "none"
+    return str(provider).strip().lower()
+
+
+def _fallback_cache(
+    exc: Exception,
+    *,
+    fallback: str,
+    ttl_seconds: float,
+    max_age_seconds: Optional[float],
+    max_refreshes: Optional[int],
+    max_entries: int,
+) -> Optional[OCRCache]:
+    normalized = _normalize_cache_provider(fallback)
+    if normalized in {"memory", "in-memory", "in_memory"}:
+        logger.warning("Redis OCR cache unavailable; falling back to MemoryOCRCache: %s", exc)
+        return MemoryOCRCache(
+            ttl_seconds=ttl_seconds,
+            max_age_seconds=max_age_seconds,
+            max_entries=max_entries,
+            max_refreshes=max_refreshes,
+        )
+    if normalized in {"none", "off", "false", "disabled", ""}:
+        logger.warning("Redis OCR cache unavailable; disabling OCR cache: %s", exc)
+        return None
+    if normalized == "raise":
+        raise exc
+    raise ValueError(f"Unknown OCR cache fallback: {fallback}") from exc
 
 
 class CachedOCR(BaseOCR):
@@ -372,9 +829,7 @@ class CachedOCR(BaseOCR):
         if miss_images:
             provider_results = self.wrapped.batch_process_images(miss_images, **kwargs)
             if len(provider_results) != len(miss_images):
-                raise RuntimeError(
-                    "OCR provider returned a different number of results than requested"
-                )
+                raise RuntimeError("OCR provider returned a different number of results than requested")
 
             for key, provider_result in zip(miss_keys, provider_results):
                 normalized = _normalize_result(provider_result)

--- a/doc2mark/pipelines/pymupdf_advanced_pipeline.py
+++ b/doc2mark/pipelines/pymupdf_advanced_pipeline.py
@@ -54,6 +54,7 @@ class PDFLoader:
         self.pdf_path = Path(pdf_path)
         self.doc = None
         self.ocr = ocr  # Store the OCR instance
+        self._first_text_page_num = None
         
         # Set table output style
         if table_style is None:
@@ -390,6 +391,35 @@ class PDFLoader:
             if zone_key in repeated:
                 item["type"] = f"text:{zone}"
 
+    def _get_first_text_page_num(self) -> int:
+        """Return the first page index containing non-empty text, falling back to 0."""
+        cached = getattr(self, "_first_text_page_num", None)
+        if cached is not None:
+            return cached
+
+        doc = getattr(self, "doc", None)
+        if doc is None:
+            return 0
+
+        try:
+            for page_num in range(len(doc)):
+                page = doc.load_page(page_num)
+                text_dict = page.get_text("dict", flags=pymupdf.TEXT_PRESERVE_LIGATURES)
+                for block in text_dict.get("blocks", []):
+                    if block.get("type") != 0:
+                        continue
+                    for line in block.get("lines", []):
+                        for span in line.get("spans", []):
+                            if span.get("text", "").strip():
+                                self._first_text_page_num = page_num
+                                return page_num
+        except Exception as e:
+            logger.debug(f"Failed to detect first text page, defaulting to page 0: {e}")
+            return 0
+
+        self._first_text_page_num = 0
+        return 0
+
     def _collect_all_images(self) -> List[Dict[str, Any]]:
         """Collect all images from all pages for batch processing
 
@@ -644,6 +674,12 @@ class PDFLoader:
         ]
 
         is_caption_pattern = any(re.match(pattern, total_text, re.IGNORECASE) for pattern in caption_patterns)
+        normalized_total_text = self._normalized_heading_text(total_text)
+        structured_total_match = self._structured_heading_match(normalized_total_text)
+        is_bare_structured_heading = (
+            structured_total_match is not None
+            and structured_total_match.end() == len(normalized_total_text)
+        )
         heading_features = self._build_heading_features(
             total_text,
             line_count=line_count,
@@ -679,12 +715,12 @@ class PDFLoader:
         # Only run further classification if not already classified as footnote
         if text_type == "text:normal":
             # Check if it's a caption (various criteria)
-            if is_caption_pattern or \
+            if (is_caption_pattern and not is_bare_structured_heading) or \
                     (self._is_near_image_or_table(block["bbox"], image_bboxes, table_bboxes) and
                      (len(total_text) < 150 or block_max_size < avg_font_size)):
                 text_type = "text:caption"
             # Check if it's a title (very large font on first few pages)
-            elif (page_num == 0
+            elif (page_num == self._get_first_text_page_num()
                   and is_heading_candidate
                   and self._has_title_layout_signal(heading_features)
                   and heading_features.length < 120
@@ -738,9 +774,20 @@ class PDFLoader:
         ]
         for pattern in structured_heading_patterns:
             match = re.match(pattern, normalized, re.IGNORECASE)
-            if match:
+            if match and self._has_structured_marker_boundary(normalized, match):
                 return match
         return None
+
+    def _has_structured_marker_boundary(self, normalized: str, match) -> bool:
+        """Avoid treating decimal/version prefixes as outline markers."""
+        if match.end() >= len(normalized):
+            return True
+        next_char = normalized[match.end()]
+        if next_char.isspace():
+            return True
+        if re.match(r'[\u4e00-\u9fff]', next_char):
+            return True
+        return not next_char.isascii() or not next_char.isalnum()
 
     def _has_list_marker(self, text: str) -> bool:
         normalized = self._normalized_heading_text(text)
@@ -748,7 +795,7 @@ class PDFLoader:
             return False
         if re.match(r'^[\u2022•\-\*\u2013\u2014\u25AA\u25AB\u25CF\u25CB\u25A0\u25A1]\s+', normalized):
             return True
-        if re.match(r'^(?:\d+|[a-zA-Z])[\.\)]\s*', normalized):
+        if re.match(r'^(?:\d+|[a-zA-Z])[\.\)]\s+', normalized):
             return True
         return self._structured_heading_match(normalized) is not None
 
@@ -761,7 +808,7 @@ class PDFLoader:
         match = self._structured_heading_match(normalized)
         if not match:
             return False
-        return bool(normalized[match.end():].strip())
+        return match.end() == len(normalized) or bool(normalized[match.end():].strip())
 
     def _build_heading_features(
         self,

--- a/doc2mark/pipelines/pymupdf_advanced_pipeline.py
+++ b/doc2mark/pipelines/pymupdf_advanced_pipeline.py
@@ -624,6 +624,8 @@ class PDFLoader:
         ]
 
         is_caption_pattern = any(re.match(pattern, total_text, re.IGNORECASE) for pattern in caption_patterns)
+        is_explicit_heading = self._is_explicit_heading_text(total_text)
+        is_heading_candidate = self._is_probable_heading_text(total_text)
 
         # Determine text type based on characteristics
         text_type = "text:normal"  # Default
@@ -649,11 +651,13 @@ class PDFLoader:
                      (len(total_text) < 150 or block_max_size < avg_font_size)):
                 text_type = "text:caption"
             # Check if it's a title (very large font on first few pages)
-            elif page_num <= 1 and block_max_size >= max_font_size * 0.85 and len(total_text) < 200 and line_count <= 3:
+            elif (page_num == 0 and is_heading_candidate and block_max_size >= max_font_size * 0.85
+                  and len(total_text) < 200 and line_count <= 3):
                 text_type = "text:title"
             # Check if it's a section header (various criteria)
-            elif (len(total_text) < 100 and line_count <= 2) and \
-                    (block_max_size > avg_font_size * 1.2 or
+            elif is_heading_candidate and (len(total_text) < 100 and line_count <= 2) and \
+                    (is_explicit_heading or
+                     block_max_size > avg_font_size * 1.2 or
                      (is_bold and block_max_size > avg_font_size * 1.05) or
                      is_all_caps):
                 text_type = "text:section"
@@ -670,6 +674,38 @@ class PDFLoader:
                 f"Classified as {text_type}: '{total_text[:50]}...' (size: {block_max_size:.1f}, avg: {avg_font_size:.1f})")
 
         return markdown_text, text_type
+
+    def _normalized_heading_text(self, text: str) -> str:
+        return re.sub(r'\s+', ' ', (text or '')).strip()
+
+    def _is_explicit_heading_text(self, text: str) -> bool:
+        normalized = self._normalized_heading_text(text)
+        explicit_heading_patterns = [
+            r'^第[一二三四五六七八九十百千\d]+[條章节章節篇]',
+            r'^(附錄|附件|附表|Appendix|Chapter|Section)\b',
+        ]
+        return any(re.match(pattern, normalized, re.IGNORECASE) for pattern in explicit_heading_patterns)
+
+    def _is_probable_heading_text(self, text: str) -> bool:
+        """Return True for text that has structural heading shape, not just larger font."""
+        normalized = self._normalized_heading_text(text)
+        if not normalized:
+            return False
+        if self._is_explicit_heading_text(normalized):
+            return True
+
+        # Legal/contract PDFs often continue body text across pages. These fragments
+        # may be large at the page top, but they are not document headings.
+        if re.search(r'[。！？!?；;，,、]', normalized):
+            return False
+        if re.match(r'^[\(（][一二三四五六七八九十百千\d]+[\)）]', normalized):
+            return False
+        if re.match(r'^[□■☑☐]', normalized):
+            return False
+        if re.match(r'^\d+[.)、．]', normalized):
+            return False
+
+        return len(normalized) <= 80
 
     def _convert_block_to_markdown(self, block: Dict[str, Any]) -> str:
         """Convert a text block to markdown format"""
@@ -719,13 +755,13 @@ class PDFLoader:
                     # Letter list (a., b., etc.) - convert to bullet
                     markdown_line = re.sub(r'^[a-zA-Z][\.\)]\s+', '- ', line_text)
             # Detect headers based on size
-            elif line_size > avg_size * 1.5:
+            elif line_size > avg_size * 1.5 and self._is_probable_heading_text(line_text):
                 # Large text -> H1
                 markdown_line = f"# {line_text}"
-            elif line_size > avg_size * 1.3:
+            elif line_size > avg_size * 1.3 and self._is_probable_heading_text(line_text):
                 # Medium large text -> H2
                 markdown_line = f"## {line_text}"
-            elif line_size > avg_size * 1.15:
+            elif line_size > avg_size * 1.15 and self._is_probable_heading_text(line_text):
                 # Slightly larger text -> H3
                 markdown_line = f"### {line_text}"
             else:

--- a/doc2mark/pipelines/pymupdf_advanced_pipeline.py
+++ b/doc2mark/pipelines/pymupdf_advanced_pipeline.py
@@ -24,6 +24,29 @@ class SimpleContent:
     mime_type: Optional[str] = None  # MIME type for image content
 
 
+@dataclass(frozen=True)
+class _HeadingFeatures:
+    normalized: str
+    length: int
+    line_count: int
+    size_ratio: float
+    max_size_ratio: float
+    is_bold: bool
+    is_all_caps: bool
+    has_list_pattern: bool
+    list_line_count: int
+    is_explicit_marker: bool
+    is_structured_marker: bool
+    text_after_marker: str
+    has_cjk: bool
+    has_checkbox_marker: bool
+    has_sentence_punctuation: bool
+    has_trailing_continuation: bool
+    separator_count: int
+    has_form_field_shape: bool
+    has_long_clause_shape: bool
+
+
 class PDFLoader:
     """PDF loader that extracts content in reading order and exports to various formats"""
 
@@ -607,10 +630,7 @@ class PDFLoader:
                 if not line_text.isupper() or not any(c.isalpha() for c in line_text):
                     is_all_caps = False
 
-                # Check for list patterns (expanded set of markers)
-                if re.match(
-                        r'^([\u2022•\-\*\u2013\u2014\u25AA\u25AB\u25CF\u25CB\u25A0\u25A1]|\d+[\.\)]|[a-zA-Z][\.\)])\s+',
-                        line_text.strip()):
+                if self._has_list_marker(line_text.strip()):
                     has_list_pattern = True
                     list_line_count += 1
 
@@ -624,8 +644,21 @@ class PDFLoader:
         ]
 
         is_caption_pattern = any(re.match(pattern, total_text, re.IGNORECASE) for pattern in caption_patterns)
-        is_explicit_heading = self._is_explicit_heading_text(total_text)
-        is_heading_candidate = self._is_probable_heading_text(total_text)
+        heading_features = self._build_heading_features(
+            total_text,
+            line_count=line_count,
+            block_max_size=block_max_size,
+            avg_font_size=avg_font_size,
+            max_font_size=max_font_size,
+            is_bold=is_bold,
+            is_all_caps=is_all_caps,
+            has_list_pattern=has_list_pattern,
+            list_line_count=list_line_count,
+        )
+        is_heading_candidate = self._is_probable_heading_features(
+            heading_features,
+            require_layout_signal=True,
+        )
 
         # Determine text type based on characteristics
         text_type = "text:normal"  # Default
@@ -651,15 +684,14 @@ class PDFLoader:
                      (len(total_text) < 150 or block_max_size < avg_font_size)):
                 text_type = "text:caption"
             # Check if it's a title (very large font on first few pages)
-            elif (page_num == 0 and is_heading_candidate and block_max_size >= max_font_size * 0.85
-                  and len(total_text) < 200 and line_count <= 3):
+            elif (page_num == 0
+                  and is_heading_candidate
+                  and self._has_title_layout_signal(heading_features)
+                  and heading_features.length < 120
+                  and line_count <= 2):
                 text_type = "text:title"
             # Check if it's a section header (various criteria)
-            elif is_heading_candidate and (len(total_text) < 100 and line_count <= 2) and \
-                    (is_explicit_heading or
-                     block_max_size > avg_font_size * 1.2 or
-                     (is_bold and block_max_size > avg_font_size * 1.05) or
-                     is_all_caps):
+            elif is_heading_candidate and heading_features.length < 100 and line_count <= 2:
                 text_type = "text:section"
             # Check if it's a list (majority of lines have list pattern)
             elif has_list_pattern and (list_line_count >= line_count * 0.5 or line_count == 1):
@@ -668,7 +700,8 @@ class PDFLoader:
         # Generate markdown
         markdown_text = self._convert_block_to_markdown(
             block,
-            preserve_structured_headings=text_type in ("text:title", "text:section")
+            preserve_structured_headings=text_type in ("text:title", "text:section"),
+            allow_heading_formatting=text_type in ("text:title", "text:section"),
         )
 
         # Debug logging for classification
@@ -681,90 +714,184 @@ class PDFLoader:
     def _normalized_heading_text(self, text: str) -> str:
         return re.sub(r'\s+', ' ', (text or '')).strip()
 
-    def _is_explicit_heading_text(self, text: str) -> bool:
-        normalized = self._normalized_heading_text(text)
+    def _explicit_heading_match(self, normalized: str):
         explicit_heading_patterns = [
             r'^第\s*[一二三四五六七八九十百千\d]+\s*[條章节章節篇]',
             r'^(附錄|附件|附表)\s*[A-Za-z\d一二三四五六七八九十百千]*',
             r'^(Appendix|Chapter|Section)\b',
         ]
-        return any(re.match(pattern, normalized, re.IGNORECASE) for pattern in explicit_heading_patterns)
+        for pattern in explicit_heading_patterns:
+            match = re.match(pattern, normalized, re.IGNORECASE)
+            if match:
+                return match
+        return None
+
+    def _structured_heading_match(self, normalized: str):
+        structured_heading_patterns = [
+            r'^\d+(?:\.\d+)+',
+            r'^\d+(?:-\d+)+',
+            r'^\d+[\.)、．]',
+            r'^[\(（]\d+[\)）]',
+            r'^[一二三四五六七八九十百千]+[、．\.]',
+            r'^[壹貳參肆伍陸柒捌玖拾]+[、．\.]',
+            r'^[\(（][一二三四五六七八九十百千]+[\)）]',
+        ]
+        for pattern in structured_heading_patterns:
+            match = re.match(pattern, normalized, re.IGNORECASE)
+            if match:
+                return match
+        return None
+
+    def _has_list_marker(self, text: str) -> bool:
+        normalized = self._normalized_heading_text(text)
+        if not normalized:
+            return False
+        if re.match(r'^[\u2022•\-\*\u2013\u2014\u25AA\u25AB\u25CF\u25CB\u25A0\u25A1]\s+', normalized):
+            return True
+        if re.match(r'^(?:\d+|[a-zA-Z])[\.\)]\s*', normalized):
+            return True
+        return self._structured_heading_match(normalized) is not None
+
+    def _is_explicit_heading_text(self, text: str) -> bool:
+        normalized = self._normalized_heading_text(text)
+        return self._explicit_heading_match(normalized) is not None
 
     def _is_structured_heading_text(self, text: str) -> bool:
         normalized = self._normalized_heading_text(text)
-        structured_heading_patterns = [
-            r'^\d+(?:\.\d+)+\s+\S',  # 1.1 Background
-            r'^\d+(?:-\d+)+\s+\S',  # 4-1-1 Work item
-            r'^\d+[\.)、．]\s*\S',  # 1. Introduction / 1) Scope / 1.目的
-            r'^[\(（]\d+[\)）]\s*\S',  # (1) Scope / （1）目的
-            r'^[一二三四五六七八九十百千]+[、．\.]\s*\S',  # 一、總則
-            r'^[壹貳參肆伍陸柒捌玖拾]+[、．\.]\s*\S',  # 壹、緣起
-            r'^[\(（][一二三四五六七八九十百千]+[\)）]\s*\S',  # （一）服務範圍
-        ]
-        return any(re.match(pattern, normalized, re.IGNORECASE) for pattern in structured_heading_patterns)
+        match = self._structured_heading_match(normalized)
+        if not match:
+            return False
+        return bool(normalized[match.end():].strip())
 
-    def _looks_like_body_text(self, text: str) -> bool:
+    def _build_heading_features(
+        self,
+        text: str,
+        *,
+        line_count: int = 1,
+        block_max_size: float = 0.0,
+        avg_font_size: float = 0.0,
+        max_font_size: float = 0.0,
+        is_bold: bool = False,
+        is_all_caps: bool = False,
+        has_list_pattern: bool = False,
+        list_line_count: int = 0,
+    ) -> _HeadingFeatures:
         normalized = self._normalized_heading_text(text)
-        if not normalized:
+        explicit_match = self._explicit_heading_match(normalized)
+        structured_match = self._structured_heading_match(normalized)
+        marker_match = explicit_match or structured_match
+        text_after_marker = normalized[marker_match.end():].strip() if marker_match else normalized
+        separator_count = sum(normalized.count(separator) for separator in (',', '，', '、', ':', '：'))
+        size_ratio = block_max_size / avg_font_size if avg_font_size > 0 else 1.0
+        max_size_ratio = block_max_size / max_font_size if max_font_size > 0 else 1.0
+        has_structured_marker = structured_match is not None and bool(text_after_marker)
+        has_long_clause_shape = (
+            has_structured_marker
+            and len(normalized) > 32
+            and any(separator in text_after_marker for separator in (',', '，', '、', ':', '：'))
+        )
+
+        return _HeadingFeatures(
+            normalized=normalized,
+            length=len(normalized),
+            line_count=line_count,
+            size_ratio=size_ratio,
+            max_size_ratio=max_size_ratio,
+            is_bold=is_bold,
+            is_all_caps=is_all_caps,
+            has_list_pattern=has_list_pattern,
+            list_line_count=list_line_count,
+            is_explicit_marker=explicit_match is not None,
+            is_structured_marker=has_structured_marker,
+            text_after_marker=text_after_marker,
+            has_cjk=bool(re.search(r'[\u4e00-\u9fff]', normalized)),
+            has_checkbox_marker=bool(re.match(r'^[□■☑☐]', normalized)),
+            has_sentence_punctuation=bool(re.search(r'[。！？!?；;]', normalized) or normalized.endswith('.')),
+            has_trailing_continuation=normalized.endswith(('，', ',', '、', '；', ';')),
+            separator_count=separator_count,
+            has_form_field_shape=bool(re.search(r'_{3,}|\.{4,}|…{2,}', normalized)),
+            has_long_clause_shape=has_long_clause_shape,
+        )
+
+    def _has_heading_layout_signal(self, features: _HeadingFeatures) -> bool:
+        return (
+            features.size_ratio >= 1.2
+            or (features.is_bold and features.size_ratio >= 1.05)
+            or features.is_all_caps
+        )
+
+    def _has_title_layout_signal(self, features: _HeadingFeatures) -> bool:
+        return (
+            features.max_size_ratio >= 0.85
+            and (features.size_ratio >= 1.15 or features.is_bold or features.is_all_caps)
+        )
+
+    def _has_hard_body_shape(self, features: _HeadingFeatures) -> bool:
+        return (
+            features.has_checkbox_marker
+            or features.has_form_field_shape
+            or features.has_sentence_punctuation
+            or features.has_trailing_continuation
+            or features.length > 120
+        )
+
+    def _has_soft_body_shape(self, features: _HeadingFeatures) -> bool:
+        if any(separator in features.text_after_marker for separator in (',', '，')) and features.length > 24:
+            return True
+        if any(separator in features.text_after_marker for separator in (':', '：')) and features.length > 30:
+            return True
+        if features.separator_count >= 3:
+            return True
+        if features.separator_count >= 2 and not features.is_structured_marker and features.length > 36:
+            return True
+        return features.has_long_clause_shape
+
+    def _is_probable_heading_features(
+        self,
+        features: _HeadingFeatures,
+        *,
+        require_layout_signal: bool = False,
+    ) -> bool:
+        if not features.normalized:
+            return False
+        if features.line_count > 2:
+            return False
+        if self._has_hard_body_shape(features):
             return False
 
-        if re.match(r'^[□■☑☐]', normalized):
-            return True
+        has_layout_signal = self._has_heading_layout_signal(features)
+        has_soft_body_shape = self._has_soft_body_shape(features)
 
-        if re.search(r'[。！？!?；;]', normalized):
-            return True
+        if features.is_explicit_marker:
+            return features.length <= 80 and not (has_soft_body_shape and features.length > 60)
 
-        if normalized.endswith(('，', ',', '、', '；', ';')):
-            return True
+        if require_layout_signal and not has_layout_signal:
+            return False
 
-        structured_marker_match = re.match(
-            r'^(\d+(?:[\.-]\d+)*[\.)、．]?|[一二三四五六七八九十百千壹貳參肆伍陸柒捌玖拾]+[、．\.]|'
-            r'[\(（][一二三四五六七八九十百千\d]+[\)）])\s*',
-            normalized,
-        )
-        text_after_marker = normalized[structured_marker_match.end():] if structured_marker_match else normalized
+        if features.is_structured_marker:
+            if features.has_long_clause_shape:
+                return False
+            if has_soft_body_shape and not has_layout_signal:
+                return False
+            return features.length <= 80
 
-        if '，' in text_after_marker and len(normalized) > 24:
-            return True
+        if has_soft_body_shape:
+            return False
 
-        if '：' in text_after_marker and len(normalized) > 30:
-            return True
-
-        chinese_separator_count = text_after_marker.count('、') + text_after_marker.count('，')
-        if chinese_separator_count >= 2:
-            return True
-
-        starts_with_numbered_clause = (
-                re.match(r'^\d+[.)、．]', normalized)
-                or re.match(r'^[\(（][一二三四五六七八九十百千\d]+[\)）]', normalized)
-        )
-        if starts_with_numbered_clause and len(normalized) > 36:
-            return True
-
-        return False
+        length_limit = 24 if features.has_cjk else 80
+        return features.length <= length_limit
 
     def _is_probable_heading_text(self, text: str) -> bool:
-        """Return True for text that has structural heading shape, not just larger font."""
-        normalized = self._normalized_heading_text(text)
-        if not normalized:
-            return False
-        if self._is_explicit_heading_text(normalized):
-            return True
+        """Return True for short structural heading shapes without body blockers."""
+        features = self._build_heading_features(text)
+        return self._is_probable_heading_features(features, require_layout_signal=False)
 
-        if self._looks_like_body_text(normalized):
-            return False
-
-        if self._is_structured_heading_text(normalized):
-            return len(normalized) <= 80
-
-        # CJK body lines are often extracted as short visual fragments. Keep plain
-        # CJK headings conservative; structured headings are handled above.
-        if re.search(r'[\u4e00-\u9fff]', normalized):
-            return len(normalized) <= 24
-
-        return len(normalized) <= 80
-
-    def _convert_block_to_markdown(self, block: Dict[str, Any], preserve_structured_headings: bool = False) -> str:
+    def _convert_block_to_markdown(
+        self,
+        block: Dict[str, Any],
+        preserve_structured_headings: bool = False,
+        allow_heading_formatting: bool = False,
+    ) -> str:
         """Convert a text block to markdown format"""
         lines = []
 
@@ -816,13 +943,13 @@ class PDFLoader:
                     # Letter list (a., b., etc.) - convert to bullet
                     markdown_line = re.sub(r'^[a-zA-Z][\.\)]\s+', '- ', line_text)
             # Detect headers based on size
-            elif line_size > avg_size * 1.5 and self._is_probable_heading_text(line_text):
+            elif allow_heading_formatting and line_size > avg_size * 1.5 and self._is_probable_heading_text(line_text):
                 # Large text -> H1
                 markdown_line = f"# {line_text}"
-            elif line_size > avg_size * 1.3 and self._is_probable_heading_text(line_text):
+            elif allow_heading_formatting and line_size > avg_size * 1.3 and self._is_probable_heading_text(line_text):
                 # Medium large text -> H2
                 markdown_line = f"## {line_text}"
-            elif line_size > avg_size * 1.15 and self._is_probable_heading_text(line_text):
+            elif allow_heading_formatting and line_size > avg_size * 1.15 and self._is_probable_heading_text(line_text):
                 # Slightly larger text -> H3
                 markdown_line = f"### {line_text}"
             else:

--- a/doc2mark/pipelines/pymupdf_advanced_pipeline.py
+++ b/doc2mark/pipelines/pymupdf_advanced_pipeline.py
@@ -620,7 +620,7 @@ class PDFLoader:
         caption_patterns = [
             r'^(Figure|Fig\.?|Table|Tbl\.?|Chart|Graph|Image|Plate|Scheme)\s*\d*[\.:)]?',
             r'^(Source|Note|Notes)[\.:)]',
-            r'^\d+\.\d+[\.:)]?',  # Numbered captions like "1.1:" or "2.3."
+            r'^\d+\.\d+[\.:)]',  # Numbered captions like "1.1:" or "2.3."
         ]
 
         is_caption_pattern = any(re.match(pattern, total_text, re.IGNORECASE) for pattern in caption_patterns)
@@ -666,7 +666,10 @@ class PDFLoader:
                 text_type = "text:list"
 
         # Generate markdown
-        markdown_text = self._convert_block_to_markdown(block)
+        markdown_text = self._convert_block_to_markdown(
+            block,
+            preserve_structured_headings=text_type in ("text:title", "text:section")
+        )
 
         # Debug logging for classification
         if text_type != "text:normal":
@@ -681,10 +684,49 @@ class PDFLoader:
     def _is_explicit_heading_text(self, text: str) -> bool:
         normalized = self._normalized_heading_text(text)
         explicit_heading_patterns = [
-            r'^第[一二三四五六七八九十百千\d]+[條章节章節篇]',
-            r'^(附錄|附件|附表|Appendix|Chapter|Section)\b',
+            r'^第\s*[一二三四五六七八九十百千\d]+\s*[條章节章節篇]',
+            r'^(附錄|附件|附表)\s*[A-Za-z\d一二三四五六七八九十百千]*',
+            r'^(Appendix|Chapter|Section)\b',
         ]
         return any(re.match(pattern, normalized, re.IGNORECASE) for pattern in explicit_heading_patterns)
+
+    def _is_structured_heading_text(self, text: str) -> bool:
+        normalized = self._normalized_heading_text(text)
+        structured_heading_patterns = [
+            r'^\d+(?:\.\d+)+\s+\S',  # 1.1 Background
+            r'^\d+[\.)、．]\s*\S',  # 1. Introduction / 1) Scope / 1.目的
+            r'^[\(（]\d+[\)）]\s*\S',  # (1) Scope / （1）目的
+            r'^[一二三四五六七八九十百千]+[、．\.]\s*\S',  # 一、總則
+            r'^[\(（][一二三四五六七八九十百千]+[\)）]\s*\S',  # （一）服務範圍
+        ]
+        return any(re.match(pattern, normalized, re.IGNORECASE) for pattern in structured_heading_patterns)
+
+    def _looks_like_body_text(self, text: str) -> bool:
+        normalized = self._normalized_heading_text(text)
+        if not normalized:
+            return False
+
+        if re.match(r'^[□■☑☐]', normalized):
+            return True
+
+        if re.search(r'[。！？!?；;]', normalized):
+            return True
+
+        if normalized.endswith(('，', ',', '、', '；', ';')):
+            return True
+
+        chinese_separator_count = normalized.count('、') + normalized.count('，')
+        if chinese_separator_count >= 2:
+            return True
+
+        starts_with_numbered_clause = (
+                re.match(r'^\d+[.)、．]', normalized)
+                or re.match(r'^[\(（][一二三四五六七八九十百千\d]+[\)）]', normalized)
+        )
+        if starts_with_numbered_clause and len(normalized) > 45:
+            return True
+
+        return False
 
     def _is_probable_heading_text(self, text: str) -> bool:
         """Return True for text that has structural heading shape, not just larger font."""
@@ -694,20 +736,15 @@ class PDFLoader:
         if self._is_explicit_heading_text(normalized):
             return True
 
-        # Legal/contract PDFs often continue body text across pages. These fragments
-        # may be large at the page top, but they are not document headings.
-        if re.search(r'[。！？!?；;，,、]', normalized):
+        if self._looks_like_body_text(normalized):
             return False
-        if re.match(r'^[\(（][一二三四五六七八九十百千\d]+[\)）]', normalized):
-            return False
-        if re.match(r'^[□■☑☐]', normalized):
-            return False
-        if re.match(r'^\d+[.)、．]', normalized):
-            return False
+
+        if self._is_structured_heading_text(normalized):
+            return len(normalized) <= 80
 
         return len(normalized) <= 80
 
-    def _convert_block_to_markdown(self, block: Dict[str, Any]) -> str:
+    def _convert_block_to_markdown(self, block: Dict[str, Any], preserve_structured_headings: bool = False) -> str:
         """Convert a text block to markdown format"""
         lines = []
 
@@ -741,7 +778,11 @@ class PDFLoader:
                 r'^([\u2022•\-\*\u2013\u2014\u25AA\u25AB\u25CF\u25CB\u25A0\u25A1]|\d+[\.\)]|[a-zA-Z][\.\)])\s+',
                 line_text)
             
-            if list_match:
+            if (preserve_structured_headings
+                    and self._is_structured_heading_text(line_text)
+                    and self._is_probable_heading_text(line_text)):
+                markdown_line = line_text
+            elif list_match:
                 # Handle list items without applying text formatting
                 marker = list_match.group(1)
                 if marker in '•\u2022\u25CF\u25AA\u25A0' or marker == '-' or marker == '*':

--- a/doc2mark/pipelines/pymupdf_advanced_pipeline.py
+++ b/doc2mark/pipelines/pymupdf_advanced_pipeline.py
@@ -694,9 +694,11 @@ class PDFLoader:
         normalized = self._normalized_heading_text(text)
         structured_heading_patterns = [
             r'^\d+(?:\.\d+)+\s+\S',  # 1.1 Background
+            r'^\d+(?:-\d+)+\s+\S',  # 4-1-1 Work item
             r'^\d+[\.)、．]\s*\S',  # 1. Introduction / 1) Scope / 1.目的
             r'^[\(（]\d+[\)）]\s*\S',  # (1) Scope / （1）目的
             r'^[一二三四五六七八九十百千]+[、．\.]\s*\S',  # 一、總則
+            r'^[壹貳參肆伍陸柒捌玖拾]+[、．\.]\s*\S',  # 壹、緣起
             r'^[\(（][一二三四五六七八九十百千]+[\)）]\s*\S',  # （一）服務範圍
         ]
         return any(re.match(pattern, normalized, re.IGNORECASE) for pattern in structured_heading_patterns)
@@ -715,7 +717,20 @@ class PDFLoader:
         if normalized.endswith(('，', ',', '、', '；', ';')):
             return True
 
-        chinese_separator_count = normalized.count('、') + normalized.count('，')
+        structured_marker_match = re.match(
+            r'^(\d+(?:[\.-]\d+)*[\.)、．]?|[一二三四五六七八九十百千壹貳參肆伍陸柒捌玖拾]+[、．\.]|'
+            r'[\(（][一二三四五六七八九十百千\d]+[\)）])\s*',
+            normalized,
+        )
+        text_after_marker = normalized[structured_marker_match.end():] if structured_marker_match else normalized
+
+        if '，' in text_after_marker and len(normalized) > 24:
+            return True
+
+        if '：' in text_after_marker and len(normalized) > 30:
+            return True
+
+        chinese_separator_count = text_after_marker.count('、') + text_after_marker.count('，')
         if chinese_separator_count >= 2:
             return True
 
@@ -723,7 +738,7 @@ class PDFLoader:
                 re.match(r'^\d+[.)、．]', normalized)
                 or re.match(r'^[\(（][一二三四五六七八九十百千\d]+[\)）]', normalized)
         )
-        if starts_with_numbered_clause and len(normalized) > 45:
+        if starts_with_numbered_clause and len(normalized) > 36:
             return True
 
         return False
@@ -741,6 +756,11 @@ class PDFLoader:
 
         if self._is_structured_heading_text(normalized):
             return len(normalized) <= 80
+
+        # CJK body lines are often extracted as short visual fragments. Keep plain
+        # CJK headings conservative; structured headings are handled above.
+        if re.search(r'[\u4e00-\u9fff]', normalized):
+            return len(normalized) <= 24
 
         return len(normalized) <= 80
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,8 +77,11 @@ vertex_ai = [
     "langchain-google-genai>=2.0.0",
     "langchain>=1.2.0",
 ]
+redis = [
+    "redis>=5.0.0",
+]
 all = [
-    "doc2mark[ocr,heif,mime,vertex_ai]",
+    "doc2mark[ocr,heif,mime,vertex_ai,redis]",
 ]
 dev = [
     "pytest>=7.0.0",

--- a/setup.py
+++ b/setup.py
@@ -56,8 +56,12 @@ setup(
         "ocr": [
             "pytesseract>=0.3.10",  # Tesseract OCR
         ],
+        "redis": [
+            "redis>=5.0.0",
+        ],
         "all": [
             "pytesseract>=0.3.10",
+            "redis>=5.0.0",
             "pyyaml>=6.0",  # For markdown frontmatter
         ]
     },

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -7,6 +7,7 @@ from unittest.mock import Mock, patch, MagicMock
 
 from doc2mark import UnifiedDocumentLoader
 from doc2mark.ocr.base import OCRProvider, OCRResult
+from doc2mark.ocr.cache import CachedOCR, MemoryOCRCache
 
 
 class TestOCRMocked:
@@ -61,6 +62,40 @@ class TestOCRMocked:
         # Check OCR provider
         from doc2mark.ocr.tesseract import TesseractOCR
         assert isinstance(loader.ocr, TesseractOCR)
+
+    def test_loader_does_not_wrap_ocr_without_cache(self):
+        """OCR cache is explicit opt-in."""
+        loader = UnifiedDocumentLoader(ocr_provider='tesseract')
+
+        from doc2mark.ocr.tesseract import TesseractOCR
+        assert isinstance(loader.ocr, TesseractOCR)
+        assert not isinstance(loader.ocr, CachedOCR)
+
+    def test_loader_wraps_ocr_when_cache_is_provided(self):
+        """Loader should wrap the configured OCR provider with CachedOCR."""
+        cache = MemoryOCRCache(ttl_seconds=60)
+        loader = UnifiedDocumentLoader(ocr_provider='tesseract', ocr_cache=cache)
+
+        assert isinstance(loader.ocr, CachedOCR)
+        assert loader.ocr.cache is cache
+        assert loader.ocr.validate_api_key() is True
+
+        summary = loader.get_ocr_configuration()
+        assert summary["provider"] == "TesseractOCR"
+
+    def test_set_ocr_provider_reuses_or_replaces_cache_handler(self):
+        """set_ocr_provider should preserve the loader cache unless a new one is supplied."""
+        original_cache = MemoryOCRCache(ttl_seconds=60)
+        replacement_cache = MemoryOCRCache(ttl_seconds=120)
+        loader = UnifiedDocumentLoader(ocr_provider='tesseract', ocr_cache=original_cache)
+
+        loader.set_ocr_provider('tesseract')
+        assert isinstance(loader.ocr, CachedOCR)
+        assert loader.ocr.cache is original_cache
+
+        loader.set_ocr_provider('tesseract', ocr_cache=replacement_cache)
+        assert isinstance(loader.ocr, CachedOCR)
+        assert loader.ocr.cache is replacement_cache
 
 
 @pytest.mark.integration

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -131,6 +131,50 @@ class TestOCRMocked:
         assert isinstance(loader.ocr, CachedOCR)
         assert loader.ocr.cache is replacement_cache
 
+    @patch('doc2mark.ocr.openai.VisionAgent')
+    def test_set_ocr_provider_preserves_openai_enhanced_config_when_attaching_cache(self, mock_vision_agent):
+        """Attaching a cache through set_ocr_provider must not reset OpenAI model settings."""
+        mock_vision_agent.return_value = MagicMock()
+        original_cache = MemoryOCRCache(ttl_seconds=60)
+        loader = UnifiedDocumentLoader(
+            ocr_provider='openai',
+            api_key='test-key-123',
+            model='gpt-4o-mini',
+            temperature=0.25,
+            max_tokens=1234,
+            prompt_template='table_focused',
+            base_url='https://example.test/v1',
+            ocr_cache=original_cache,
+        )
+        replacement_cache = MemoryOCRCache(ttl_seconds=120)
+
+        loader.set_ocr_provider('openai', ocr_cache=replacement_cache)
+
+        assert isinstance(loader.ocr, CachedOCR)
+        assert loader.ocr.cache is replacement_cache
+        wrapped = loader.ocr.wrapped
+        assert wrapped.model == 'gpt-4o-mini'
+        assert wrapped.temperature == 0.25
+        assert wrapped.max_tokens == 1234
+        assert wrapped.prompt_template.value == 'table_focused'
+        assert wrapped.base_url == 'https://example.test/v1'
+        assert wrapped.api_key == 'test-key-123'
+
+    def test_set_ocr_provider_preserves_embedded_cached_ocr_backend(self):
+        """A supplied CachedOCR keeps its embedded cache unless an explicit cache is provided."""
+        from doc2mark.ocr.tesseract import TesseractOCR
+
+        stale_cache = MemoryOCRCache(ttl_seconds=60)
+        embedded_cache = MemoryOCRCache(ttl_seconds=120)
+        loader = UnifiedDocumentLoader(ocr_provider='tesseract', ocr_cache=stale_cache)
+        supplied = CachedOCR(TesseractOCR(), embedded_cache)
+
+        loader.set_ocr_provider(supplied)
+
+        assert loader.ocr is supplied
+        assert loader.ocr.cache is embedded_cache
+        assert loader.ocr_cache is embedded_cache
+
 
 @pytest.mark.integration
 @pytest.mark.skipif(

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -1,13 +1,27 @@
 """Tests for OCR functionality."""
 
 import os
+import sys
 import pytest
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import Mock, patch, MagicMock
 
 from doc2mark import UnifiedDocumentLoader
 from doc2mark.ocr.base import OCRProvider, OCRResult
-from doc2mark.ocr.cache import CachedOCR, MemoryOCRCache
+from doc2mark.ocr.cache import CachedOCR, MemoryOCRCache, RedisOCRCache, create_ocr_cache
+
+
+class LoaderFakeRedis:
+    def ping(self):
+        return True
+
+
+def install_loader_fake_redis(monkeypatch):
+    client = LoaderFakeRedis()
+    fake_module = SimpleNamespace(from_url=lambda redis_url: client)
+    monkeypatch.setitem(sys.modules, "redis", fake_module)
+    return client
 
 
 class TestOCRMocked:
@@ -82,6 +96,26 @@ class TestOCRMocked:
 
         summary = loader.get_ocr_configuration()
         assert summary["provider"] == "TesseractOCR"
+
+    def test_loader_wraps_ocr_when_factory_cache_is_provided(self):
+        """Factory-created caches should be passed through unchanged."""
+        cache = create_ocr_cache("memory", ttl_seconds=60)
+        loader = UnifiedDocumentLoader(ocr_provider='tesseract', ocr_cache=cache)
+
+        assert isinstance(loader.ocr, CachedOCR)
+        assert loader.ocr.cache is cache
+
+    def test_loader_wraps_ocr_when_redis_cache_is_provided(self, monkeypatch):
+        """RedisOCRCache should only be used as a prebuilt cache handler by the loader."""
+        install_loader_fake_redis(monkeypatch)
+        cache = create_ocr_cache("redis", redis_url="redis://localhost/0", key_prefix="loader")
+
+        assert isinstance(cache, RedisOCRCache)
+
+        loader = UnifiedDocumentLoader(ocr_provider='tesseract', ocr_cache=cache)
+
+        assert isinstance(loader.ocr, CachedOCR)
+        assert loader.ocr.cache is cache
 
     def test_set_ocr_provider_reuses_or_replaces_cache_handler(self):
         """set_ocr_provider should preserve the loader cache unless a new one is supplied."""

--- a/tests/test_ocr_cache.py
+++ b/tests/test_ocr_cache.py
@@ -1,0 +1,168 @@
+"""Tests for request-scoped OCR cache behavior."""
+
+import pytest
+
+from doc2mark.ocr.base import BaseOCR, OCRConfig, OCRResult
+from doc2mark.ocr.cache import CachedOCR, MemoryOCRCache
+
+
+class FakeOCR(BaseOCR):
+    def __init__(self, fail=False):
+        super().__init__(api_key="fake-key", config=OCRConfig(language="en"))
+        self.fail = fail
+        self.calls = []
+        self.model = "fake-model"
+        self.temperature = 0
+        self.max_tokens = 128
+        self.prompt_template = "default"
+        self.default_prompt = "Read the image"
+        self.model_kwargs = {"top_p": 1.0}
+
+    def batch_process_images(self, images, **kwargs):
+        if self.fail:
+            raise ValueError("provider failed")
+        self.calls.append(list(images))
+        language = kwargs.get("language", "none")
+        return [
+            OCRResult(
+                text=f"{image.decode('utf-8')}:{language}",
+                metadata={"size": len(image)},
+            )
+            for image in images
+        ]
+
+    def validate_api_key(self):
+        return True
+
+    def get_configuration_summary(self):
+        return {"provider": "FakeOCR", "model": self.model}
+
+
+def test_memory_cache_hit_miss_and_clear():
+    cache = MemoryOCRCache(ttl_seconds=60, max_entries=10)
+
+    assert cache.get("missing") is None
+    cache.set("key", OCRResult(text="cached"))
+
+    assert cache.get("key").text == "cached"
+    cache.clear()
+    assert cache.get("key") is None
+
+    stats = cache.stats()
+    assert stats["hits"] == 1
+    assert stats["misses"] == 2
+    assert stats["entries"] == 0
+
+
+def test_memory_cache_ttl_refresh_respects_max_age():
+    current = [1000.0]
+    cache = MemoryOCRCache(
+        ttl_seconds=10,
+        max_age_seconds=25,
+        max_entries=10,
+        time_func=lambda: current[0],
+    )
+
+    cache.set("key", OCRResult(text="cached"))
+
+    current[0] = 1009.0
+    assert cache.get("key").text == "cached"
+
+    current[0] = 1018.0
+    assert cache.get("key").text == "cached"
+
+    current[0] = 1025.0
+    assert cache.get("key") is None
+    assert cache.stats()["expired"] == 1
+
+
+def test_memory_cache_max_entries_evicts_lru_item():
+    cache = MemoryOCRCache(ttl_seconds=60, max_entries=2)
+    cache.set("a", OCRResult(text="a"))
+    cache.set("b", OCRResult(text="b"))
+
+    assert cache.get("a").text == "a"
+    cache.set("c", OCRResult(text="c"))
+
+    assert cache.get("b") is None
+    assert cache.get("a").text == "a"
+    assert cache.get("c").text == "c"
+    assert cache.stats()["evictions"] == 1
+
+
+def test_cached_ocr_dedupes_duplicate_images_within_batch():
+    provider = FakeOCR()
+    cache = MemoryOCRCache(ttl_seconds=60)
+    ocr = CachedOCR(provider, cache)
+
+    results = ocr.batch_process_images(
+        [b"same", b"same", b"other"],
+        language="en",
+    )
+
+    assert [result.text for result in results] == ["same:en", "same:en", "other:en"]
+    assert provider.calls == [[b"same", b"other"]]
+    assert cache.stats()["sets"] == 2
+
+
+def test_cached_ocr_reuses_result_across_batches():
+    provider = FakeOCR()
+    cache = MemoryOCRCache(ttl_seconds=60)
+    ocr = CachedOCR(provider, cache)
+
+    first = ocr.batch_process_images([b"same"], language="en")
+    second = ocr.batch_process_images([b"same"], language="en")
+
+    assert first[0].text == "same:en"
+    assert second[0].text == "same:en"
+    assert len(provider.calls) == 1
+    assert cache.stats()["hits"] == 1
+
+
+def test_cached_ocr_uses_call_kwargs_in_cache_key():
+    provider = FakeOCR()
+    cache = MemoryOCRCache(ttl_seconds=60)
+    ocr = CachedOCR(provider, cache)
+
+    english = ocr.batch_process_images([b"same"], language="en")
+    chinese = ocr.batch_process_images([b"same"], language="zh")
+
+    assert english[0].text == "same:en"
+    assert chinese[0].text == "same:zh"
+    assert len(provider.calls) == 2
+    assert cache.stats()["sets"] == 2
+
+
+def test_cached_ocr_does_not_cache_provider_failures():
+    provider = FakeOCR(fail=True)
+    cache = MemoryOCRCache(ttl_seconds=60)
+    ocr = CachedOCR(provider, cache)
+
+    with pytest.raises(ValueError, match="provider failed"):
+        ocr.batch_process_images([b"same"], language="en")
+
+    assert cache.stats()["entries"] == 0
+    assert cache.get("anything") is None
+
+
+def test_cached_ocr_process_image_uses_cache():
+    provider = FakeOCR()
+    cache = MemoryOCRCache(ttl_seconds=60)
+    ocr = CachedOCR(provider, cache)
+
+    first = ocr.process_image(b"single", language="en")
+    second = ocr.process_image(b"single", language="en")
+
+    assert first.text == "single:en"
+    assert second.text == "single:en"
+    assert len(provider.calls) == 1
+
+
+def test_memory_cache_stores_results_without_image_bytes():
+    cache = MemoryOCRCache(ttl_seconds=60)
+    cache.set("key", OCRResult(text="cached", metadata={"note": "no bytes"}))
+
+    entry = cache._entries["key"]
+    assert entry.result.text == "cached"
+    assert not hasattr(entry, "image")
+    assert not hasattr(entry.result, "image")

--- a/tests/test_ocr_cache.py
+++ b/tests/test_ocr_cache.py
@@ -1,9 +1,28 @@
-"""Tests for request-scoped OCR cache behavior."""
+"""Tests for OCR cache behavior."""
+
+import fnmatch
+import sys
+from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
+from doc2mark import RedisOCRCache as ExportedRedisOCRCache
+from doc2mark import create_ocr_cache as exported_create_ocr_cache
+from doc2mark.ocr import RedisOCRCache as OCRPackageRedisOCRCache
+from doc2mark.ocr import create_ocr_cache as ocr_package_create_ocr_cache
 from doc2mark.ocr.base import BaseOCR, OCRConfig, OCRResult
-from doc2mark.ocr.cache import CachedOCR, MemoryOCRCache
+from doc2mark.ocr.cache import (
+    OCR_CACHE_VALUE_SCHEMA_VERSION,
+    CachedOCR,
+    MemoryOCRCache,
+    NoOpOCRCache,
+    RedisOCRCache,
+    _deserialize_ocr_cache_entry,
+    _serialize_ocr_cache_entry,
+    build_ocr_cache_key,
+    create_ocr_cache,
+)
 
 
 class FakeOCR(BaseOCR):
@@ -38,6 +57,151 @@ class FakeOCR(BaseOCR):
         return {"provider": "FakeOCR", "model": self.model}
 
 
+class FakeWatchError(Exception):
+    pass
+
+
+class FakeRedisPipeline:
+    def __init__(self, client):
+        self.client = client
+        self.commands = []
+        self.in_multi = False
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.reset()
+        return False
+
+    def watch(self, key):
+        self.watched_key = key
+
+    def unwatch(self):
+        self.watched_key = None
+
+    def get(self, key):
+        return self.client.get(key)
+
+    def multi(self):
+        self.in_multi = True
+
+    def set(self, key, value, ex=None):
+        if self.in_multi:
+            self.commands.append(("set", key, value, ex))
+            return None
+        return self.client.set(key, value, ex=ex)
+
+    def delete(self, *keys):
+        if self.in_multi:
+            self.commands.append(("delete", keys))
+            return None
+        return self.client.delete(*keys)
+
+    def execute(self):
+        results = []
+        for command in self.commands:
+            if command[0] == "set":
+                _, key, value, ex = command
+                results.append(self.client.set(key, value, ex=ex))
+            elif command[0] == "delete":
+                _, keys = command
+                results.append(self.client.delete(*keys))
+        self.reset()
+        return results
+
+    def reset(self):
+        self.commands = []
+        self.in_multi = False
+
+
+class FakeRedisClient:
+    def __init__(self):
+        self.store = {}
+        self.ping_called = False
+        self.set_calls = []
+        self.deleted_keys = []
+        self.raise_on = set()
+
+    def ping(self):
+        if "ping" in self.raise_on:
+            raise RuntimeError("ping failed")
+        self.ping_called = True
+        return True
+
+    def get(self, key):
+        if "get" in self.raise_on:
+            raise RuntimeError("get failed")
+        return self.store.get(key)
+
+    def set(self, key, value, ex=None):
+        if "set" in self.raise_on:
+            raise RuntimeError("set failed")
+        self.store[key] = value
+        self.set_calls.append((key, value, ex))
+        return True
+
+    def delete(self, *keys):
+        if "delete" in self.raise_on:
+            raise RuntimeError("delete failed")
+        deleted = 0
+        for key in keys:
+            if isinstance(key, bytes):
+                key = key.decode("utf-8")
+            if key in self.store:
+                deleted += 1
+                self.deleted_keys.append(key)
+                del self.store[key]
+        return deleted
+
+    def scan(self, cursor=0, match=None, count=None):
+        if "scan" in self.raise_on:
+            raise RuntimeError("scan failed")
+        keys = [key for key in self.store if match is None or fnmatch.fnmatch(key, match)]
+        return 0, keys
+
+    def pipeline(self):
+        return FakeRedisPipeline(self)
+
+
+def install_fake_redis(monkeypatch, client=None, from_url_error=None):
+    client = client or FakeRedisClient()
+
+    def from_url(redis_url):
+        if from_url_error is not None:
+            raise from_url_error
+        client.redis_url = redis_url
+        return client
+
+    fake_module = SimpleNamespace(
+        from_url=from_url,
+        WatchError=FakeWatchError,
+        exceptions=SimpleNamespace(WatchError=FakeWatchError),
+    )
+    monkeypatch.setitem(sys.modules, "redis", fake_module)
+    return client
+
+
+def assert_common_stats(stats, backend):
+    assert stats["backend"] == backend
+    for key in (
+        "hits",
+        "misses",
+        "sets",
+        "refreshes",
+        "refresh_skipped",
+        "expired",
+        "evictions",
+        "deletes",
+        "errors",
+        "entries",
+        "ttl_seconds",
+        "max_age_seconds",
+        "max_refreshes",
+    ):
+        assert key in stats
+
+
 def test_memory_cache_hit_miss_and_clear():
     cache = MemoryOCRCache(ttl_seconds=60, max_entries=10)
 
@@ -49,9 +213,11 @@ def test_memory_cache_hit_miss_and_clear():
     assert cache.get("key") is None
 
     stats = cache.stats()
+    assert_common_stats(stats, "memory")
     assert stats["hits"] == 1
     assert stats["misses"] == 2
     assert stats["entries"] == 0
+    assert stats["deletes"] == 1
 
 
 def test_memory_cache_ttl_refresh_respects_max_age():
@@ -76,6 +242,36 @@ def test_memory_cache_ttl_refresh_respects_max_age():
     assert cache.stats()["expired"] == 1
 
 
+def test_memory_cache_max_refreshes_hits_without_extending_after_limit():
+    current = [1000.0]
+    cache = MemoryOCRCache(
+        ttl_seconds=10,
+        max_age_seconds=100,
+        max_refreshes=1,
+        time_func=lambda: current[0],
+    )
+
+    cache.set("key", OCRResult(text="cached"))
+
+    current[0] = 1005.0
+    assert cache.get("key").text == "cached"
+    assert cache._entries["key"].expires_at == 1015.0
+    assert cache._entries["key"].refresh_count == 1
+
+    current[0] = 1012.0
+    assert cache.get("key").text == "cached"
+    assert cache._entries["key"].expires_at == 1015.0
+
+    current[0] = 1016.0
+    assert cache.get("key") is None
+
+    stats = cache.stats()
+    assert stats["hits"] == 2
+    assert stats["refreshes"] == 1
+    assert stats["refresh_skipped"] == 1
+    assert stats["expired"] == 1
+
+
 def test_memory_cache_max_entries_evicts_lru_item():
     cache = MemoryOCRCache(ttl_seconds=60, max_entries=2)
     cache.set("a", OCRResult(text="a"))
@@ -88,6 +284,297 @@ def test_memory_cache_max_entries_evicts_lru_item():
     assert cache.get("a").text == "a"
     assert cache.get("c").text == "c"
     assert cache.stats()["evictions"] == 1
+
+
+def test_noop_cache_stats_are_schema_compatible():
+    cache = NoOpOCRCache()
+    assert cache.get("missing") is None
+    cache.set("key", OCRResult(text="ignored"))
+
+    stats = cache.stats()
+    assert_common_stats(stats, "noop")
+    assert stats["entries"] == 0
+    assert stats["ttl_seconds"] is None
+    assert stats["max_age_seconds"] is None
+    assert stats["max_refreshes"] is None
+
+
+def test_serialization_round_trips_result_without_sensitive_metadata():
+    payload = _serialize_ocr_cache_entry(
+        OCRResult(
+            text="cached",
+            confidence=0.9,
+            language="en",
+            metadata={"api_key": "secret", "raw": b"image-bytes", "page": 3},
+        ),
+        created_at=1000.0,
+        expires_at=1060.0,
+        refresh_count=2,
+    )
+
+    assert "secret" not in payload
+    assert "image-bytes" not in payload
+    entry = _deserialize_ocr_cache_entry(payload)
+
+    assert entry.result.text == "cached"
+    assert entry.result.confidence == 0.9
+    assert entry.result.language == "en"
+    assert entry.result.metadata["page"] == 3
+    assert "api_key" not in entry.result.metadata
+    assert "bytes_sha256" in entry.result.metadata["raw"]
+    assert entry.created_at == 1000.0
+    assert entry.expires_at == 1060.0
+    assert entry.refresh_count == 2
+
+
+def test_deserialize_rejects_schema_mismatch_and_malformed_payload():
+    with pytest.raises(ValueError):
+        _deserialize_ocr_cache_entry("not-json")
+
+    with pytest.raises(ValueError):
+        _deserialize_ocr_cache_entry(
+            {
+                "schema": "old-schema",
+                "result": {"text": "cached"},
+                "created_at": 1000,
+                "expires_at": 1060,
+            }
+        )
+
+
+def test_cache_key_includes_provider_backend_identity():
+    provider = FakeOCR()
+    image = b"same-image"
+
+    provider.base_url = "https://endpoint-a.example"
+    endpoint_a_key = build_ocr_cache_key(provider, image)
+
+    provider.base_url = "https://endpoint-b.example"
+    endpoint_b_key = build_ocr_cache_key(provider, image)
+
+    assert endpoint_a_key != endpoint_b_key
+
+    provider.base_url = None
+    provider.project = "project-a"
+    provider.location = "global"
+    project_a_key = build_ocr_cache_key(provider, image)
+
+    provider.project = "project-b"
+    provider.location = "asia-east1"
+    project_b_key = build_ocr_cache_key(provider, image)
+
+    assert project_a_key != project_b_key
+
+
+def test_redis_constructor_imports_lazily_and_pings(monkeypatch):
+    client = install_fake_redis(monkeypatch)
+
+    cache = RedisOCRCache("redis://localhost/0", key_prefix="test")
+
+    assert cache.redis_url == "redis://localhost/0"
+    assert client.redis_url == "redis://localhost/0"
+    assert client.ping_called is True
+    assert_common_stats(cache.stats(), "redis")
+
+
+def test_redis_constructor_raises_when_package_is_missing(monkeypatch):
+    monkeypatch.setitem(sys.modules, "redis", None)
+
+    with pytest.raises(ImportError):
+        RedisOCRCache("redis://localhost/0")
+
+
+def test_redis_cache_set_get_refreshes_ttl(monkeypatch):
+    current = [1000.0]
+    client = install_fake_redis(monkeypatch)
+    cache = RedisOCRCache(
+        "redis://localhost/0",
+        ttl_seconds=10,
+        max_age_seconds=25,
+        max_refreshes=2,
+        key_prefix="test",
+        time_func=lambda: current[0],
+    )
+
+    cache.set("key", OCRResult(text="cached"))
+    assert client.set_calls[-1][0] == "test:key"
+    assert client.set_calls[-1][2] == 10
+
+    current[0] = 1005.0
+    assert cache.get("key").text == "cached"
+
+    entry = _deserialize_ocr_cache_entry(client.store["test:key"])
+    assert entry.expires_at == 1015.0
+    assert entry.refresh_count == 1
+
+    stats = cache.stats()
+    assert stats["hits"] == 1
+    assert stats["sets"] == 1
+    assert stats["refreshes"] == 1
+    assert stats["entries"] is None
+
+
+def test_redis_cache_miss_and_expired_value_delete(monkeypatch):
+    current = [1000.0]
+    client = install_fake_redis(monkeypatch)
+    cache = RedisOCRCache("redis://localhost/0", ttl_seconds=10, key_prefix="test", time_func=lambda: current[0])
+
+    assert cache.get("missing") is None
+    cache.set("key", OCRResult(text="cached"))
+
+    current[0] = 1011.0
+    assert cache.get("key") is None
+    assert "test:key" not in client.store
+
+    stats = cache.stats()
+    assert stats["misses"] == 2
+    assert stats["expired"] == 1
+    assert stats["deletes"] == 1
+
+
+def test_redis_cache_max_refreshes_returns_hit_without_extending(monkeypatch):
+    current = [1000.0]
+    client = install_fake_redis(monkeypatch)
+    cache = RedisOCRCache(
+        "redis://localhost/0",
+        ttl_seconds=10,
+        max_age_seconds=100,
+        max_refreshes=1,
+        key_prefix="test",
+        time_func=lambda: current[0],
+    )
+
+    cache.set("key", OCRResult(text="cached"))
+
+    current[0] = 1005.0
+    assert cache.get("key").text == "cached"
+    assert _deserialize_ocr_cache_entry(client.store["test:key"]).expires_at == 1015.0
+
+    current[0] = 1012.0
+    assert cache.get("key").text == "cached"
+    assert _deserialize_ocr_cache_entry(client.store["test:key"]).expires_at == 1015.0
+
+    current[0] = 1016.0
+    assert cache.get("key") is None
+
+    stats = cache.stats()
+    assert stats["hits"] == 2
+    assert stats["refreshes"] == 1
+    assert stats["refresh_skipped"] == 1
+    assert stats["expired"] == 1
+
+
+def test_redis_cache_refresh_respects_max_age_cap(monkeypatch):
+    current = [1000.0]
+    client = install_fake_redis(monkeypatch)
+    cache = RedisOCRCache(
+        "redis://localhost/0",
+        ttl_seconds=10,
+        max_age_seconds=12,
+        key_prefix="test",
+        time_func=lambda: current[0],
+    )
+
+    cache.set("key", OCRResult(text="cached"))
+
+    current[0] = 1009.0
+    assert cache.get("key").text == "cached"
+    assert _deserialize_ocr_cache_entry(client.store["test:key"]).expires_at == 1012.0
+
+    current[0] = 1012.0
+    assert cache.get("key") is None
+    assert cache.stats()["expired"] == 1
+
+
+def test_redis_cache_deletes_malformed_value(monkeypatch):
+    client = install_fake_redis(monkeypatch)
+    cache = RedisOCRCache("redis://localhost/0", key_prefix="test")
+    client.store["test:key"] = "not-json"
+
+    assert cache.get("key") is None
+    assert "test:key" not in client.store
+
+    stats = cache.stats()
+    assert stats["misses"] == 1
+    assert stats["deletes"] == 1
+
+
+def test_redis_runtime_errors_fail_open(monkeypatch):
+    client = install_fake_redis(monkeypatch)
+    cache = RedisOCRCache("redis://localhost/0", key_prefix="test")
+
+    client.raise_on.add("get")
+    assert cache.get("key") is None
+
+    client.raise_on.remove("get")
+    client.raise_on.add("set")
+    cache.set("key", OCRResult(text="cached"))
+
+    stats = cache.stats()
+    assert stats["errors"] == 2
+    assert stats["misses"] == 0
+    assert stats["sets"] == 0
+
+
+def test_redis_clear_scans_only_configured_prefix(monkeypatch):
+    client = install_fake_redis(monkeypatch)
+    cache = RedisOCRCache("redis://localhost/0", key_prefix="test")
+    client.store["test:a"] = _serialize_ocr_cache_entry(
+        OCRResult(text="a"),
+        created_at=1000,
+        expires_at=1060,
+    )
+    client.store["other:b"] = _serialize_ocr_cache_entry(
+        OCRResult(text="b"),
+        created_at=1000,
+        expires_at=1060,
+    )
+
+    cache.clear()
+
+    assert "test:a" not in client.store
+    assert "other:b" in client.store
+    assert cache.stats()["deletes"] == 1
+
+
+def test_create_ocr_cache_provider_aliases(monkeypatch):
+    assert create_ocr_cache(None) is None
+    assert create_ocr_cache("none") is None
+    assert isinstance(create_ocr_cache("noop"), NoOpOCRCache)
+    assert isinstance(create_ocr_cache("memory", ttl_seconds=5), MemoryOCRCache)
+    assert isinstance(create_ocr_cache("in-memory", ttl_seconds=5), MemoryOCRCache)
+
+    install_fake_redis(monkeypatch)
+    cache = create_ocr_cache("redis", redis_url="redis://localhost/0", key_prefix="test")
+    assert isinstance(cache, RedisOCRCache)
+
+
+def test_create_ocr_cache_redis_fallbacks(monkeypatch):
+    install_fake_redis(monkeypatch, from_url_error=RuntimeError("connection failed"))
+
+    memory_cache = create_ocr_cache(
+        "redis",
+        redis_url="redis://localhost/0",
+        fallback="memory",
+        ttl_seconds=5,
+        max_entries=3,
+    )
+    assert isinstance(memory_cache, MemoryOCRCache)
+    assert memory_cache.ttl_seconds == 5
+    assert memory_cache.max_entries == 3
+
+    assert create_ocr_cache("redis", redis_url="redis://localhost/0", fallback="none") is None
+
+    with pytest.raises(RuntimeError, match="connection failed"):
+        create_ocr_cache("redis", redis_url="redis://localhost/0", fallback="raise")
+
+
+def test_create_ocr_cache_falls_back_when_redis_package_missing(monkeypatch):
+    monkeypatch.setitem(sys.modules, "redis", None)
+
+    cache = create_ocr_cache("redis", redis_url="redis://localhost/0", fallback="memory")
+
+    assert isinstance(cache, MemoryOCRCache)
 
 
 def test_cached_ocr_dedupes_duplicate_images_within_batch():
@@ -166,3 +653,30 @@ def test_memory_cache_stores_results_without_image_bytes():
     assert entry.result.text == "cached"
     assert not hasattr(entry, "image")
     assert not hasattr(entry.result, "image")
+
+
+def test_public_exports_are_available_without_instantiating_redis(monkeypatch):
+    monkeypatch.setitem(sys.modules, "redis", None)
+
+    assert ExportedRedisOCRCache is RedisOCRCache
+    assert OCRPackageRedisOCRCache is RedisOCRCache
+    assert exported_create_ocr_cache is create_ocr_cache
+    assert ocr_package_create_ocr_cache is create_ocr_cache
+
+
+def test_packaging_declares_redis_extra():
+    project_root = Path(__file__).resolve().parents[1]
+    pyproject_text = (project_root / "pyproject.toml").read_text(encoding="utf-8")
+    setup_text = (project_root / "setup.py").read_text(encoding="utf-8")
+
+    assert "redis = [" in pyproject_text
+    assert '"redis>=5.0.0"' in pyproject_text
+    assert '"doc2mark[ocr,heif,mime,vertex_ai,redis]"' in pyproject_text
+
+    assert '"redis": [' in setup_text
+    assert '"redis>=5.0.0",' in setup_text
+    assert '"all": [' in setup_text
+
+
+def test_value_schema_version_is_private_value_schema():
+    assert OCR_CACHE_VALUE_SCHEMA_VERSION == "ocr-cache-value-v1"

--- a/tests/test_ocr_cache.py
+++ b/tests/test_ocr_cache.py
@@ -13,6 +13,7 @@ from doc2mark.ocr import RedisOCRCache as OCRPackageRedisOCRCache
 from doc2mark.ocr import create_ocr_cache as ocr_package_create_ocr_cache
 from doc2mark.ocr.base import BaseOCR, OCRConfig, OCRResult
 from doc2mark.ocr.cache import (
+    CACHE_SCHEMA_VERSION,
     OCR_CACHE_VALUE_SCHEMA_VERSION,
     CachedOCR,
     MemoryOCRCache,
@@ -366,6 +367,48 @@ def test_cache_key_includes_provider_backend_identity():
     assert project_a_key != project_b_key
 
 
+def test_cache_key_schema_and_api_key_identity_are_credential_scoped():
+    provider = FakeOCR()
+    image = b"same-image"
+
+    provider.api_key = "tenant-a-secret"
+    tenant_a_key = build_ocr_cache_key(provider, image)
+
+    provider.api_key = "tenant-b-secret"
+    tenant_b_key = build_ocr_cache_key(provider, image)
+
+    assert CACHE_SCHEMA_VERSION == "ocr-cache-v3"
+    assert tenant_a_key != tenant_b_key
+    assert "tenant-a-secret" not in tenant_a_key
+    assert "tenant-b-secret" not in tenant_b_key
+
+
+def test_cache_key_rejects_address_based_unstable_values():
+    class CustomClient:
+        pass
+
+    provider = FakeOCR()
+    provider.model_kwargs = {"client": CustomClient()}
+
+    with pytest.raises(TypeError, match="stable OCR cache key"):
+        build_ocr_cache_key(provider, b"image")
+
+
+def test_cache_value_serialization_does_not_embed_object_addresses():
+    class CustomClient:
+        pass
+
+    payload = _serialize_ocr_cache_entry(
+        OCRResult(text="cached", metadata={"client": CustomClient()}),
+        created_at=1000,
+        expires_at=1060,
+    )
+
+    assert "0x" not in payload
+    entry = _deserialize_ocr_cache_entry(payload)
+    assert entry.result.metadata["client"]["type"].endswith("CustomClient")
+
+
 def test_redis_constructor_imports_lazily_and_pings(monkeypatch):
     client = install_fake_redis(monkeypatch)
 
@@ -630,6 +673,35 @@ def test_cached_ocr_does_not_cache_provider_failures():
 
     assert cache.stats()["entries"] == 0
     assert cache.get("anything") is None
+
+
+def test_cached_ocr_caches_aligned_prefix_on_count_mismatch():
+    class ShortResultOCR(FakeOCR):
+        def batch_process_images(self, images, **kwargs):
+            self.calls.append(list(images))
+            return [OCRResult(text="first")]
+
+    provider = ShortResultOCR()
+    cache = MemoryOCRCache(ttl_seconds=60)
+    ocr = CachedOCR(provider, cache)
+
+    with pytest.raises(RuntimeError, match="different number of results"):
+        ocr.batch_process_images([b"first", b"second"], language="en")
+
+    first_key = build_ocr_cache_key(provider, b"first", kwargs={"language": "en"})
+    second_key = build_ocr_cache_key(provider, b"second", kwargs={"language": "en"})
+    assert cache.get(first_key).text == "first"
+    assert cache.get(second_key) is None
+
+
+def test_cached_ocr_getattr_does_not_recurse_without_wrapped():
+    ocr = CachedOCR.__new__(CachedOCR)
+
+    with pytest.raises(AttributeError):
+        getattr(ocr, "wrapped")
+
+    with pytest.raises(AttributeError):
+        getattr(ocr, "model")
 
 
 def test_cached_ocr_process_image_uses_cache():

--- a/tests/test_pdf_heading_heuristics.py
+++ b/tests/test_pdf_heading_heuristics.py
@@ -1,6 +1,24 @@
 from doc2mark.pipelines.pymupdf_advanced_pipeline import PDFLoader
 
 
+LONG_CJK_SENTENCE = "甲" * 12 + "，" + "乙" * 18 + "。"
+LONG_CJK_COMMA_FRAGMENT = "甲" * 16 + "，" + "乙" * 20
+NUMBERED_LONG_CJK_CLAUSE = "5. " + "甲" * 10 + "，" + "乙" * 20
+PARENTHESIZED_LONG_CJK_CLAUSE = "(1) " + "甲" * 10 + "，" + "乙" * 20
+CHECKBOX_FORM_FIELD = "□" + "甲" * 8 + "：" + "_" * 8 + "元。"
+ARTICLE_CJK_HEADING = "第二條  甲乙事項"
+SHORT_CJK_TITLE = "甲乙丙丁"
+SHORT_CJK_HEADING = "甲乙事項"
+CJK_OUTLINE_HEADING = "一、甲乙事項"
+CJK_OUTLINE_HEADING_WITH_SEPARATORS = "陸、甲乙事項、丙丁事項"
+
+LONG_LATIN_SENTENCE = "Alpha beta gamma delta epsilon zeta eta theta iota."
+LONG_LATIN_COMMA_FRAGMENT = "Alpha beta gamma, delta epsilon zeta eta theta iota"
+NUMBERED_LONG_LATIN_CLAUSE = "3. Alpha beta gamma, delta epsilon zeta eta theta iota"
+SHORT_LATIN_HEADING = "Alpha Beta"
+LATIN_COMMA_HEADING = "Alpha, Beta and Gamma"
+
+
 def make_loader():
     return PDFLoader.__new__(PDFLoader)
 
@@ -35,129 +53,159 @@ def classify(block, page_num=1, avg_font_size=10.0, max_font_size=12.0):
     )
 
 
-def test_page_continuation_body_text_is_not_title():
-    block = make_block(
-        [
-            ("文為準。其因譯文有誤致生損害者，由提供譯文之一方負責賠償。", 12.0),
-            ("3.契約所稱申請、報告、同意、指示、核准、通知、解釋及其他類似行為", 12.0),
-        ]
-    )
-
-    markdown, text_type = classify(block, page_num=1)
-
-    assert text_type == "text:normal"
+def assert_not_markdown_heading(markdown):
     assert not markdown.lstrip().startswith("#")
 
 
-def test_parenthesized_contract_clause_is_not_title():
-    block = make_block(
-        [
-            ("(2)國際組織、外國政府或其授權機構、公會或商會所出具之文件。", 12.0),
-            ("(3)其他經機關認定確有必要者。", 12.0),
-        ]
-    )
-
-    markdown, text_type = classify(block, page_num=1)
+def test_long_cjk_sentence_is_not_heading():
+    markdown, text_type = classify(make_block([(LONG_CJK_SENTENCE, 12.1)]))
 
     assert text_type == "text:normal"
-    assert not markdown.lstrip().startswith("#")
+    assert_not_markdown_heading(markdown)
 
 
-def test_checkbox_contract_option_is_not_heading():
-    block = make_block(
-        [
-            ("□總包價法。契約價金：________元(由機關填寫)。", 12.0),
-        ]
-    )
-
-    markdown, text_type = classify(block, page_num=1)
+def test_long_cjk_comma_fragment_is_not_heading():
+    markdown, text_type = classify(make_block([(LONG_CJK_COMMA_FRAGMENT, 12.1)]))
 
     assert text_type == "text:normal"
-    assert not markdown.lstrip().startswith("#")
+    assert_not_markdown_heading(markdown)
 
 
-def test_numbered_contract_option_is_not_heading():
-    block = make_block(
-        [
-            ("1.服務成本加公費法之服務費用        元(由機關於決標後填寫)，", 12.0),
-        ]
-    )
-
-    markdown, text_type = classify(block, page_num=1)
+def test_long_latin_sentence_is_not_heading():
+    markdown, text_type = classify(make_block([(LONG_LATIN_SENTENCE, 12.1)]))
 
     assert text_type == "text:normal"
-    assert not markdown.lstrip().startswith("#")
+    assert_not_markdown_heading(markdown)
+
+
+def test_long_latin_comma_fragment_is_not_heading():
+    markdown, text_type = classify(make_block([(LONG_LATIN_COMMA_FRAGMENT, 12.1)]))
+
+    assert text_type == "text:normal"
+    assert_not_markdown_heading(markdown)
+
+
+def test_trailing_continuation_fragment_is_not_heading():
+    markdown, text_type = classify(make_block([("Alpha beta gamma,", 12.1)]))
+
+    assert text_type == "text:normal"
+    assert_not_markdown_heading(markdown)
+
+
+def test_checkbox_form_field_is_not_heading():
+    markdown, text_type = classify(make_block([(CHECKBOX_FORM_FIELD, 12.1)]))
+
+    assert text_type == "text:normal"
+    assert_not_markdown_heading(markdown)
+
+
+def test_numbered_long_cjk_clause_remains_list_not_heading():
+    markdown, text_type = classify(
+        make_block([(NUMBERED_LONG_CJK_CLAUSE, 12.1)]),
+        avg_font_size=10.0,
+        max_font_size=14.0,
+    )
+
+    assert text_type == "text:list"
+    assert_not_markdown_heading(markdown)
+
+
+def test_numbered_long_latin_clause_remains_list_not_heading():
+    markdown, text_type = classify(
+        make_block([(NUMBERED_LONG_LATIN_CLAUSE, 12.1)]),
+        avg_font_size=10.0,
+        max_font_size=14.0,
+    )
+
+    assert text_type == "text:list"
+    assert_not_markdown_heading(markdown)
+
+
+def test_parenthesized_long_clause_is_not_heading():
+    markdown, text_type = classify(
+        make_block([(PARENTHESIZED_LONG_CJK_CLAUSE, 12.1)]),
+        avg_font_size=10.0,
+        max_font_size=14.0,
+    )
+
+    assert text_type in {"text:list", "text:normal"}
+    assert_not_markdown_heading(markdown)
 
 
 def test_large_body_text_line_does_not_emit_markdown_heading():
     block = make_block(
         [
-            ("文為準。其因譯文有誤致生損害者，由提供譯文之一方負責賠償。", 14.0),
-            ("普通正文", 10.0),
+            (LONG_CJK_SENTENCE, 14.0),
+            (SHORT_CJK_HEADING, 10.0),
         ]
     )
 
-    markdown, text_type = classify(block, page_num=1)
+    markdown, text_type = classify(block)
 
     assert text_type == "text:normal"
-    assert "# 文為準" not in markdown
+    assert_not_markdown_heading(markdown)
 
 
-def test_explicit_contract_article_is_section():
-    block = make_block([("第二條  履約標的", 12.0)])
-
-    markdown, text_type = classify(block, page_num=1)
+def test_cjk_article_marker_is_section():
+    markdown, text_type = classify(make_block([(ARTICLE_CJK_HEADING, 12.0)]))
 
     assert text_type == "text:section"
-    assert markdown.strip() == "第二條  履約標的"
+    assert markdown.strip() == ARTICLE_CJK_HEADING
 
 
-def test_first_page_document_name_remains_title():
-    block = make_block([("勞務採購契約範本", 12.0)])
-
-    markdown, text_type = classify(block, page_num=0)
+def test_first_page_short_text_with_title_layout_is_title():
+    markdown, text_type = classify(make_block([(SHORT_CJK_TITLE, 12.0)]), page_num=0)
 
     assert text_type == "text:title"
-    assert markdown.strip() == "勞務採購契約範本"
+    assert markdown.strip() == SHORT_CJK_TITLE
 
 
-def test_english_structural_headings_remain_sections():
+def test_english_explicit_headings_remain_sections():
     for heading in [
-        "Chapter 1 Introduction",
-        "Section 2 Background",
-        "Appendix A Data Dictionary",
+        "Chapter 1 Alpha",
+        "Section 2 Beta",
+        "Appendix A Gamma",
     ]:
-        markdown, text_type = classify(make_block([(heading, 12.0)]), page_num=1)
+        markdown, text_type = classify(make_block([(heading, 12.0)]))
 
         assert text_type == "text:section"
         assert markdown.strip() == heading
 
 
-def test_short_unmarked_heading_can_use_font_size_signal():
-    block = make_block([("履約管理", 12.1)])
-
+def test_short_unmarked_heading_requires_layout_signal():
     markdown, text_type = classify(
-        block,
-        page_num=1,
+        make_block([(SHORT_CJK_HEADING, 12.1)]),
         avg_font_size=10.0,
         max_font_size=14.0,
     )
 
     assert text_type == "text:section"
-    assert markdown.strip() == "履約管理"
+    assert markdown.strip() == SHORT_CJK_HEADING
 
 
-def test_numbered_headings_can_use_font_size_signal():
+def test_short_unmarked_text_without_layout_signal_is_normal():
+    markdown, text_type = classify(
+        make_block([(SHORT_CJK_HEADING, 10.0)]),
+        avg_font_size=10.0,
+        max_font_size=14.0,
+    )
+
+    assert text_type == "text:normal"
+    assert markdown.strip() == SHORT_CJK_HEADING
+
+
+def test_structured_headings_can_use_layout_signal():
     for heading in [
-        "1. Introduction",
-        "1) Scope",
-        "1.1 Background",
-        "(1) Scope",
-        "1.目的",
+        "1. Alpha",
+        "1) Alpha",
+        "1.1 Alpha Beta",
+        "(1) Alpha",
+        "1.甲乙事項",
+        CJK_OUTLINE_HEADING,
+        "（一）甲乙事項",
     ]:
         markdown, text_type = classify(
             make_block([(heading, 12.1)]),
-            page_num=1,
             avg_font_size=10.0,
             max_font_size=14.0,
         )
@@ -166,92 +214,45 @@ def test_numbered_headings_can_use_font_size_signal():
         assert markdown.strip() == heading
 
 
-def test_chinese_structured_headings_can_use_font_size_signal():
-    for heading in [
-        "一、總則",
-        "（一）服務範圍",
-    ]:
-        markdown, text_type = classify(
-            make_block([(heading, 12.1)]),
-            page_num=1,
-            avg_font_size=10.0,
-            max_font_size=14.0,
-        )
-
-        assert text_type == "text:section"
-        assert markdown.strip() == heading
-
-
-def test_short_heading_with_comma_can_use_font_size_signal():
-    block = make_block([("Revenue, Costs and Margin", 12.1)])
-
+def test_structured_marker_without_layout_signal_remains_list():
     markdown, text_type = classify(
-        block,
-        page_num=1,
-        avg_font_size=10.0,
-        max_font_size=14.0,
-    )
-
-    assert text_type == "text:section"
-    assert markdown.strip() == "Revenue, Costs and Margin"
-
-
-def test_numbered_list_without_heading_layout_remains_list():
-    block = make_block([("1. regular list item", 10.0)])
-
-    markdown, text_type = classify(
-        block,
-        page_num=1,
+        make_block([("1. Alpha beta", 10.0)]),
         avg_font_size=10.0,
         max_font_size=14.0,
     )
 
     assert text_type == "text:list"
-    assert markdown.strip() == "1. regular list item"
+    assert markdown.strip() == "1. Alpha beta"
 
 
-def test_formal_chinese_chapter_heading_with_multiple_separators_is_section():
-    block = make_block([("陸、推動組織、資源需求及計畫管理", 12.1)])
-
+def test_short_latin_heading_can_use_font_size_signal():
     markdown, text_type = classify(
-        block,
-        page_num=1,
+        make_block([(SHORT_LATIN_HEADING, 12.1)]),
         avg_font_size=10.0,
         max_font_size=14.0,
     )
 
     assert text_type == "text:section"
-    assert markdown.strip() == "陸、推動組織、資源需求及計畫管理"
+    assert markdown.strip() == SHORT_LATIN_HEADING
 
 
-def test_real_world_body_fragments_with_chinese_commas_are_not_headings():
-    for text in [
-        "發展方案(106 至114 年)」(DIGI+方案)，並在奠基於5+2 產業創新基",
-        "隨著人工智慧與新興技術發展，多份報告均指出生成式AI 的出",
-        "日本總務省於2022 年8 月12 日發布《2022 年ICT 網際安全綜",
-        "並推動國內政府機關與民間企業通過國際資安標準驗證(如ISO",
-        "各CI 主管機關落實防護基準執行控制措施、辦理資安治理成熟",
-    ]:
-        markdown, text_type = classify(
-            make_block([(text, 12.1)]),
-            page_num=1,
-            avg_font_size=10.0,
-            max_font_size=14.0,
-        )
-
-        assert text_type == "text:normal"
-        assert not markdown.lstrip().startswith("#")
-
-
-def test_numbered_body_clause_with_chinese_comma_remains_list_not_heading():
-    text = "5. 針對CI 的重要作業系統，規劃推動建置資訊安全管理制度"
-
+def test_short_latin_heading_with_comma_can_use_font_size_signal():
     markdown, text_type = classify(
-        make_block([(text, 12.1)]),
-        page_num=1,
+        make_block([(LATIN_COMMA_HEADING, 12.1)]),
         avg_font_size=10.0,
         max_font_size=14.0,
     )
 
-    assert text_type == "text:list"
-    assert not markdown.lstrip().startswith("#")
+    assert text_type == "text:section"
+    assert markdown.strip() == LATIN_COMMA_HEADING
+
+
+def test_cjk_outline_heading_with_multiple_separators_can_be_section():
+    markdown, text_type = classify(
+        make_block([(CJK_OUTLINE_HEADING_WITH_SEPARATORS, 12.1)]),
+        avg_font_size=10.0,
+        max_font_size=14.0,
+    )
+
+    assert text_type == "text:section"
+    assert markdown.strip() == CJK_OUTLINE_HEADING_WITH_SEPARATORS

--- a/tests/test_pdf_heading_heuristics.py
+++ b/tests/test_pdf_heading_heuristics.py
@@ -208,3 +208,50 @@ def test_numbered_list_without_heading_layout_remains_list():
 
     assert text_type == "text:list"
     assert markdown.strip() == "1. regular list item"
+
+
+def test_formal_chinese_chapter_heading_with_multiple_separators_is_section():
+    block = make_block([("陸、推動組織、資源需求及計畫管理", 12.1)])
+
+    markdown, text_type = classify(
+        block,
+        page_num=1,
+        avg_font_size=10.0,
+        max_font_size=14.0,
+    )
+
+    assert text_type == "text:section"
+    assert markdown.strip() == "陸、推動組織、資源需求及計畫管理"
+
+
+def test_real_world_body_fragments_with_chinese_commas_are_not_headings():
+    for text in [
+        "發展方案(106 至114 年)」(DIGI+方案)，並在奠基於5+2 產業創新基",
+        "隨著人工智慧與新興技術發展，多份報告均指出生成式AI 的出",
+        "日本總務省於2022 年8 月12 日發布《2022 年ICT 網際安全綜",
+        "並推動國內政府機關與民間企業通過國際資安標準驗證(如ISO",
+        "各CI 主管機關落實防護基準執行控制措施、辦理資安治理成熟",
+    ]:
+        markdown, text_type = classify(
+            make_block([(text, 12.1)]),
+            page_num=1,
+            avg_font_size=10.0,
+            max_font_size=14.0,
+        )
+
+        assert text_type == "text:normal"
+        assert not markdown.lstrip().startswith("#")
+
+
+def test_numbered_body_clause_with_chinese_comma_remains_list_not_heading():
+    text = "5. 針對CI 的重要作業系統，規劃推動建置資訊安全管理制度"
+
+    markdown, text_type = classify(
+        make_block([(text, 12.1)]),
+        page_num=1,
+        avg_font_size=10.0,
+        max_font_size=14.0,
+    )
+
+    assert text_type == "text:list"
+    assert not markdown.lstrip().startswith("#")

--- a/tests/test_pdf_heading_heuristics.py
+++ b/tests/test_pdf_heading_heuristics.py
@@ -23,6 +23,49 @@ def make_loader():
     return PDFLoader.__new__(PDFLoader)
 
 
+class FakePage:
+    def __init__(self, texts):
+        self._texts = texts
+
+    def get_text(self, *args, **kwargs):
+        return {
+            "blocks": [
+                {
+                    "type": 0,
+                    "lines": [
+                        {
+                            "spans": [
+                                {
+                                    "text": text,
+                                    "size": 10.0,
+                                    "flags": 0,
+                                }
+                            ]
+                        }
+                    ],
+                }
+                for text in self._texts
+            ]
+        }
+
+
+class FakeDoc:
+    def __init__(self, pages):
+        self._pages = pages
+
+    def __len__(self):
+        return len(self._pages)
+
+    def load_page(self, page_num):
+        return self._pages[page_num]
+
+
+def make_loader_with_doc(doc):
+    loader = make_loader()
+    loader.doc = doc
+    return loader
+
+
 def make_block(lines):
     return {
         "bbox": (72.0, 70.0, 520.0, 110.0),
@@ -41,8 +84,8 @@ def make_block(lines):
     }
 
 
-def classify(block, page_num=1, avg_font_size=10.0, max_font_size=12.0):
-    loader = make_loader()
+def classify(block, page_num=1, avg_font_size=10.0, max_font_size=12.0, loader=None):
+    loader = loader or make_loader()
     return loader._convert_block_to_markdown_with_type(
         block,
         avg_font_size=avg_font_size,
@@ -160,6 +203,32 @@ def test_first_page_short_text_with_title_layout_is_title():
     assert markdown.strip() == SHORT_CJK_TITLE
 
 
+def test_title_can_appear_on_first_text_page_after_blank_page():
+    loader = make_loader_with_doc(FakeDoc([FakePage([]), FakePage(["甲乙丙丁"])]))
+
+    markdown, text_type = classify(
+        make_block([(SHORT_CJK_TITLE, 12.0)]),
+        page_num=1,
+        loader=loader,
+    )
+
+    assert text_type == "text:title"
+    assert markdown.strip() == SHORT_CJK_TITLE
+
+
+def test_second_page_title_layout_is_not_title_when_first_page_has_text():
+    loader = make_loader_with_doc(FakeDoc([FakePage(["封面文字"]), FakePage(["甲乙丙丁"])]))
+
+    markdown, text_type = classify(
+        make_block([(SHORT_CJK_TITLE, 12.0)]),
+        page_num=1,
+        loader=loader,
+    )
+
+    assert text_type != "text:title"
+    assert markdown.strip() == SHORT_CJK_TITLE
+
+
 def test_english_explicit_headings_remain_sections():
     for heading in [
         "Chapter 1 Alpha",
@@ -223,6 +292,29 @@ def test_structured_marker_without_layout_signal_remains_list():
 
     assert text_type == "text:list"
     assert markdown.strip() == "1. Alpha beta"
+
+
+def test_decimal_and_abbreviation_shapes_are_not_list_markers():
+    for text in ["1.5x faster", "2.0release", "A.D."]:
+        markdown, text_type = classify(
+            make_block([(text, 10.0)]),
+            avg_font_size=10.0,
+            max_font_size=14.0,
+        )
+
+        assert text_type == "text:normal"
+        assert markdown.strip() == text
+
+
+def test_bare_structured_heading_is_preserved_in_section_block():
+    markdown, text_type = classify(
+        make_block([("3.1.2", 12.1)]),
+        avg_font_size=10.0,
+        max_font_size=14.0,
+    )
+
+    assert text_type == "text:section"
+    assert markdown.strip() == "3.1.2"
 
 
 def test_short_latin_heading_can_use_font_size_signal():

--- a/tests/test_pdf_heading_heuristics.py
+++ b/tests/test_pdf_heading_heuristics.py
@@ -145,3 +145,66 @@ def test_short_unmarked_heading_can_use_font_size_signal():
 
     assert text_type == "text:section"
     assert markdown.strip() == "履約管理"
+
+
+def test_numbered_headings_can_use_font_size_signal():
+    for heading in [
+        "1. Introduction",
+        "1) Scope",
+        "1.1 Background",
+        "(1) Scope",
+        "1.目的",
+    ]:
+        markdown, text_type = classify(
+            make_block([(heading, 12.1)]),
+            page_num=1,
+            avg_font_size=10.0,
+            max_font_size=14.0,
+        )
+
+        assert text_type == "text:section"
+        assert markdown.strip() == heading
+
+
+def test_chinese_structured_headings_can_use_font_size_signal():
+    for heading in [
+        "一、總則",
+        "（一）服務範圍",
+    ]:
+        markdown, text_type = classify(
+            make_block([(heading, 12.1)]),
+            page_num=1,
+            avg_font_size=10.0,
+            max_font_size=14.0,
+        )
+
+        assert text_type == "text:section"
+        assert markdown.strip() == heading
+
+
+def test_short_heading_with_comma_can_use_font_size_signal():
+    block = make_block([("Revenue, Costs and Margin", 12.1)])
+
+    markdown, text_type = classify(
+        block,
+        page_num=1,
+        avg_font_size=10.0,
+        max_font_size=14.0,
+    )
+
+    assert text_type == "text:section"
+    assert markdown.strip() == "Revenue, Costs and Margin"
+
+
+def test_numbered_list_without_heading_layout_remains_list():
+    block = make_block([("1. regular list item", 10.0)])
+
+    markdown, text_type = classify(
+        block,
+        page_num=1,
+        avg_font_size=10.0,
+        max_font_size=14.0,
+    )
+
+    assert text_type == "text:list"
+    assert markdown.strip() == "1. regular list item"

--- a/tests/test_pdf_heading_heuristics.py
+++ b/tests/test_pdf_heading_heuristics.py
@@ -1,0 +1,147 @@
+from doc2mark.pipelines.pymupdf_advanced_pipeline import PDFLoader
+
+
+def make_loader():
+    return PDFLoader.__new__(PDFLoader)
+
+
+def make_block(lines):
+    return {
+        "bbox": (72.0, 70.0, 520.0, 110.0),
+        "lines": [
+            {
+                "spans": [
+                    {
+                        "text": text,
+                        "size": size,
+                        "flags": 0,
+                    }
+                ]
+            }
+            for text, size in lines
+        ],
+    }
+
+
+def classify(block, page_num=1, avg_font_size=10.0, max_font_size=12.0):
+    loader = make_loader()
+    return loader._convert_block_to_markdown_with_type(
+        block,
+        avg_font_size=avg_font_size,
+        max_font_size=max_font_size,
+        page_num=page_num,
+        image_bboxes=[],
+        table_bboxes=[],
+    )
+
+
+def test_page_continuation_body_text_is_not_title():
+    block = make_block(
+        [
+            ("文為準。其因譯文有誤致生損害者，由提供譯文之一方負責賠償。", 12.0),
+            ("3.契約所稱申請、報告、同意、指示、核准、通知、解釋及其他類似行為", 12.0),
+        ]
+    )
+
+    markdown, text_type = classify(block, page_num=1)
+
+    assert text_type == "text:normal"
+    assert not markdown.lstrip().startswith("#")
+
+
+def test_parenthesized_contract_clause_is_not_title():
+    block = make_block(
+        [
+            ("(2)國際組織、外國政府或其授權機構、公會或商會所出具之文件。", 12.0),
+            ("(3)其他經機關認定確有必要者。", 12.0),
+        ]
+    )
+
+    markdown, text_type = classify(block, page_num=1)
+
+    assert text_type == "text:normal"
+    assert not markdown.lstrip().startswith("#")
+
+
+def test_checkbox_contract_option_is_not_heading():
+    block = make_block(
+        [
+            ("□總包價法。契約價金：________元(由機關填寫)。", 12.0),
+        ]
+    )
+
+    markdown, text_type = classify(block, page_num=1)
+
+    assert text_type == "text:normal"
+    assert not markdown.lstrip().startswith("#")
+
+
+def test_numbered_contract_option_is_not_heading():
+    block = make_block(
+        [
+            ("1.服務成本加公費法之服務費用        元(由機關於決標後填寫)，", 12.0),
+        ]
+    )
+
+    markdown, text_type = classify(block, page_num=1)
+
+    assert text_type == "text:normal"
+    assert not markdown.lstrip().startswith("#")
+
+
+def test_large_body_text_line_does_not_emit_markdown_heading():
+    block = make_block(
+        [
+            ("文為準。其因譯文有誤致生損害者，由提供譯文之一方負責賠償。", 14.0),
+            ("普通正文", 10.0),
+        ]
+    )
+
+    markdown, text_type = classify(block, page_num=1)
+
+    assert text_type == "text:normal"
+    assert "# 文為準" not in markdown
+
+
+def test_explicit_contract_article_is_section():
+    block = make_block([("第二條  履約標的", 12.0)])
+
+    markdown, text_type = classify(block, page_num=1)
+
+    assert text_type == "text:section"
+    assert markdown.strip() == "第二條  履約標的"
+
+
+def test_first_page_document_name_remains_title():
+    block = make_block([("勞務採購契約範本", 12.0)])
+
+    markdown, text_type = classify(block, page_num=0)
+
+    assert text_type == "text:title"
+    assert markdown.strip() == "勞務採購契約範本"
+
+
+def test_english_structural_headings_remain_sections():
+    for heading in [
+        "Chapter 1 Introduction",
+        "Section 2 Background",
+        "Appendix A Data Dictionary",
+    ]:
+        markdown, text_type = classify(make_block([(heading, 12.0)]), page_num=1)
+
+        assert text_type == "text:section"
+        assert markdown.strip() == heading
+
+
+def test_short_unmarked_heading_can_use_font_size_signal():
+    block = make_block([("履約管理", 12.1)])
+
+    markdown, text_type = classify(
+        block,
+        page_num=1,
+        avg_font_size=10.0,
+        max_font_size=14.0,
+    )
+
+    assert text_type == "text:section"
+    assert markdown.strip() == "履約管理"


### PR DESCRIPTION
## Summary

This PR adds a production-ready OCR cache layer and refactors PDF heading detection to avoid sample-specific heading/body heuristics.

The OCR cache work introduces memory, Redis, and no-op cache backends with a factory API, stable cache key construction, value serialization, shared stats fields, and optional Redis packaging support.

The PDF heading work replaces sample-driven tests and ad hoc heading guards with a conservative shape/layout-based classifier. The classifier now relies on structural markers, font/layout strength, punctuation shape, form-field signals, list markers, and body blockers instead of document-specific language.

## Changes

### OCR cache

- Add `MemoryOCRCache`, `RedisOCRCache`, `NoOpOCRCache`, `CachedOCR`, and `create_ocr_cache()`.
- Add stable OCR cache key construction including:
  - provider class identity
  - OCR config
  - model / prompt / model kwargs / call kwargs
  - provider backend identity fields such as `base_url`, `project`, and `location`
- Add private cache value schema serialization/deserialization.
- Add refresh support with `max_refreshes`.
- Add unified stats fields across cache backends:
  - `backend`
  - `hits`
  - `misses`
  - `sets`
  - `refreshes`
  - `refresh_skipped`
  - `expired`
  - `evictions`
  - `deletes`
  - `errors`
  - `entries`
  - `ttl_seconds`
  - `max_age_seconds`
  - `max_refreshes`
- Add Redis fail-open behavior for runtime cache operations.
- Make `RedisOCRCache(redis_url=...)` validate immediately via `redis.from_url(...).ping()`.
- Make factory fallback handle Redis initialization failures.
- Define Redis `cleanup()` as TTL-managed no-op returning `0`.
- Define Redis `clear()` as explicit prefix-scoped `SCAN` + `DEL`.
- Add Redis optional extra to both `pyproject.toml` and `setup.py`, including the `all` extra.
- Do not add `DiskOCRCache`; production persistence is expected to come from Redis RDB/AOF configuration.

### PDF heading heuristics

- Refactor PDF heading classification around private shape/layout features.
- Keep output types unchanged:
  - `text:title`
  - `text:section`
  - `text:list`
  - `text:normal`
- Make heading detection conservative:
  - only high-confidence title/section blocks can emit Markdown heading formatting
  - uncertain content remains body/list
- Preserve generic structural heading markers:
  - `第N條/章/節`
  - `Appendix / Chapter / Section`
  - `1.1`, `1-1`, `1.`, `1)`, `(1)`, `一、`, `(一)`
- Add body blockers for:
  - long prose
  - sentence-ending punctuation
  - trailing continuation punctuation
  - high separator density
  - checkbox/form-field shape
  - long numbered clauses
- Rewrite PDF heading tests with semantic-free CJK and Latin shape fixtures.
- Remove sample-specific test language tied to particular contracts, reports, security documents, or real-world snippets.

## Notes

- Redis cache key schema changed to include provider backend identity. Existing Redis cache entries may naturally miss once and be rebuilt.
- Redis is optional and only required when installing the Redis extra.
- No public PDF heading API was added; the classifier remains private implementation detail.

## Tests

Ran in the dev container:

- `python3 -m pytest tests/test_pdf_heading_heuristics.py -q`
  - `20 passed`
- `python3 -m pytest tests/test_ocr_cache.py tests/test_ocr.py -q`
  - `43 passed, 3 skipped`
- `python3 -m pytest -q`
  - `374 passed, 11 skipped`
- `git diff --check`
  - passed

Also ran the heading review gate for sample-specific terms in the PDF heading implementation/tests; no matches remained.