### PR TITLE
feat(ocr): configurable max_concurrency for LLM OCR batch processing

### DIFF
--- a/doc2mark/__init__.py
+++ b/doc2mark/__init__.py
@@ -4,7 +4,7 @@ A Python package that unifies document processing across multiple formats
 with advanced AI-powered OCR capabilities.
 """
 
-__version__ = "0.5.1"
+__version__ = "0.5.2"
 __author__ = "Hao Liang Wen"
 __email__ = "luisleo52655@gmail.com"
 

--- a/doc2mark/ocr/base.py
+++ b/doc2mark/ocr/base.py
@@ -1,9 +1,31 @@
 """Base OCR interface for doc2mark."""
 
+import os
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Dict, List, Optional, Union
+
+
+def resolve_max_concurrency(config_value: Optional[int] = None) -> Optional[int]:
+    """Resolve the LLM-OCR batch concurrency cap.
+
+    Precedence: explicit ``config_value`` > ``OCR_MAX_CONCURRENCY`` env var > ``None``.
+    ``None`` means "use the LangChain default" (a CPU-tied thread pool, typically ~12),
+    preserving the pre-0.5.2 behaviour. A positive int caps how many image OCR calls run
+    concurrently in ``batch_as_completed`` — raise it to keep large scanned documents
+    within an SLA (e.g. 32 ≈ a few-thousand-page doc in minutes).
+    """
+    if config_value is not None:
+        return config_value
+    env = os.getenv("OCR_MAX_CONCURRENCY")
+    if env:
+        try:
+            value = int(env)
+            return value if value > 0 else None
+        except ValueError:
+            return None
+    return None
 
 
 class OCRProvider(Enum):
@@ -32,6 +54,10 @@ class OCRConfig:
     max_retries: int = 3
     timeout: int = 30
     extra: Optional[Dict[str, Any]] = None
+    # Max concurrent image OCR calls for LLM providers (vertex_ai/openai) in
+    # batch_as_completed. None = LangChain default (~CPU-tied). Falls back to the
+    # OCR_MAX_CONCURRENCY env var when None. Raise for large scanned docs.
+    max_concurrency: Optional[int] = None
 
 
 class BaseOCR(ABC):

--- a/doc2mark/ocr/openai.py
+++ b/doc2mark/ocr/openai.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from doc2mark.core.base import OCRError
-from doc2mark.ocr.base import BaseOCR, OCRConfig, OCRProvider, OCRResult, OCRFactory
+from doc2mark.ocr.base import BaseOCR, OCRConfig, OCRProvider, OCRResult, OCRFactory, resolve_max_concurrency
 from doc2mark.utils.image_utils import (
     detect_image_format as _shared_detect_image_format,
     convert_image_to_supported_format as _shared_convert_image_to_supported_format,
@@ -131,7 +131,8 @@ class VisionAgent:
             model: str = "gpt-4.1",
             temperature: float = 0,
             max_tokens: int = 4096,
-            base_url: Optional[str] = None
+            base_url: Optional[str] = None,
+            max_concurrency: Optional[int] = None
     ):
         """Initialize the vision agent.
         
@@ -147,6 +148,7 @@ class VisionAgent:
         self.temperature = temperature
         self.max_tokens = max_tokens
         self.base_url = base_url or os.environ.get('OPENAI_BASE_URL')
+        self.max_concurrency = max_concurrency
 
         if not LANGCHAIN_AVAILABLE:
             logger.warning("⚠️  LangChain not available - falling back to basic OpenAI client")
@@ -201,9 +203,13 @@ class VisionAgent:
         if not self._chain:
             raise RuntimeError("LangChain not available")
 
-        logger.info(f"🚀 Starting LangChain batch processing of {len(input_dicts)} images")
+        logger.info(
+            f"🚀 Starting LangChain batch processing of {len(input_dicts)} images "
+            f"(max_concurrency={self.max_concurrency or 'default'})"
+        )
 
-        results = self._chain.batch_as_completed(input_dicts)
+        _cfg = {"max_concurrency": self.max_concurrency} if self.max_concurrency else None
+        results = self._chain.batch_as_completed(input_dicts, config=_cfg)
         sorted_results = sorted(results, key=lambda x: x[0])
 
         logger.info(f"✅ LangChain batch processing complete")
@@ -320,7 +326,10 @@ class OpenAIOCR(BaseOCR):
                 model=self.model,
                 temperature=self.temperature,
                 max_tokens=self.max_tokens,
-                base_url=self.base_url
+                base_url=self.base_url,
+                max_concurrency=resolve_max_concurrency(
+                    self.config.max_concurrency if self.config else None
+                )
             )
         except Exception as e:
             logger.error(f"❌ Failed to initialize VisionAgent: {e}")
@@ -425,7 +434,10 @@ class OpenAIOCR(BaseOCR):
                 model=self.model,
                 temperature=self.temperature,
                 max_tokens=self.max_tokens,
-                base_url=self.base_url
+                base_url=self.base_url,
+                max_concurrency=resolve_max_concurrency(
+                    self.config.max_concurrency if self.config else None
+                )
             )
         except Exception as e:
             logger.error(f"❌ Failed to reinitialize VisionAgent: {e}")

--- a/doc2mark/ocr/vertex_ai.py
+++ b/doc2mark/ocr/vertex_ai.py
@@ -6,7 +6,7 @@ import os
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from doc2mark.core.base import OCRError
-from doc2mark.ocr.base import BaseOCR, OCRConfig, OCRProvider, OCRResult, OCRFactory
+from doc2mark.ocr.base import BaseOCR, OCRConfig, OCRProvider, OCRResult, OCRFactory, resolve_max_concurrency
 from doc2mark.utils.image_utils import (
     detect_image_format as _shared_detect_image_format,
     convert_image_to_supported_format as _shared_convert_image_to_supported_format,
@@ -73,12 +73,14 @@ class VertexAIVisionAgent:
         model: str = "gemini-3.1-flash-lite-preview",
         temperature: float = 0,
         max_tokens: int = 4096,
+        max_concurrency: Optional[int] = None,
     ):
         self.project = project or os.environ.get("GOOGLE_CLOUD_PROJECT")
         self.location = location
         self.model = model
         self.temperature = temperature
         self.max_tokens = max_tokens
+        self.max_concurrency = max_concurrency
 
         if not LANGCHAIN_GOOGLE_GENAI_AVAILABLE:
             logger.warning("langchain-google-genai not available")
@@ -143,9 +145,13 @@ class VertexAIVisionAgent:
         if not self._chain:
             raise RuntimeError("langchain-google-genai not available")
 
-        logger.info(f"Starting Gemini batch processing of {len(input_dicts)} images")
+        logger.info(
+            f"Starting Gemini batch processing of {len(input_dicts)} images "
+            f"(max_concurrency={self.max_concurrency or 'default'})"
+        )
 
-        results = self._chain.batch_as_completed(input_dicts)
+        _cfg = {"max_concurrency": self.max_concurrency} if self.max_concurrency else None
+        results = self._chain.batch_as_completed(input_dicts, config=_cfg)
         sorted_results = sorted(results, key=lambda x: x[0])
 
         logger.info("Gemini batch processing complete")
@@ -234,6 +240,9 @@ class VertexAIOCR(BaseOCR):
                 model=self.model,
                 temperature=self.temperature,
                 max_tokens=self.max_tokens,
+                max_concurrency=resolve_max_concurrency(
+                    self.config.max_concurrency if self.config else None
+                ),
             )
         except Exception as e:
             logger.error(f"Failed to initialize Vertex AI VisionAgent: {e}")

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="doc2mark",
-    version="0.5.1",
+    version="0.5.2",
     author="HaoLiangWen",
     author_email="luisleo52655@gmail.com",
     description="AI-powered universal document processor with GPT-4V OCR",

--- a/tests/test_ocr_concurrency.py
+++ b/tests/test_ocr_concurrency.py
@@ -1,0 +1,57 @@
+"""Configurable LLM-OCR batch concurrency (max_concurrency).
+
+The vertex_ai / openai providers OCR all page-images via LangChain
+``batch_as_completed``. Before 0.5.2 that ran at LangChain's CPU-tied default
+(~12), which made large scanned PDFs slow with no way to raise it. These tests
+pin the new behaviour: an explicit ``OCRConfig.max_concurrency`` (or the
+``OCR_MAX_CONCURRENCY`` env var) is threaded into ``batch_as_completed``'s config.
+"""
+from unittest.mock import MagicMock
+
+from doc2mark.ocr.base import resolve_max_concurrency
+
+
+def test_resolve_precedence(monkeypatch):
+    monkeypatch.delenv("OCR_MAX_CONCURRENCY", raising=False)
+    assert resolve_max_concurrency(None) is None        # default = library default
+    assert resolve_max_concurrency(16) == 16            # explicit value
+    monkeypatch.setenv("OCR_MAX_CONCURRENCY", "48")
+    assert resolve_max_concurrency(None) == 48          # env fallback
+    assert resolve_max_concurrency(16) == 16            # explicit wins over env
+    monkeypatch.setenv("OCR_MAX_CONCURRENCY", "0")
+    assert resolve_max_concurrency(None) is None        # non-positive -> default
+    monkeypatch.setenv("OCR_MAX_CONCURRENCY", "not-an-int")
+    assert resolve_max_concurrency(None) is None        # invalid -> default
+
+
+def _agent_with_chain(cls, max_concurrency):
+    """Build a vision agent without invoking its LLM __init__, with a mock chain."""
+    agent = cls.__new__(cls)
+    agent.max_concurrency = max_concurrency
+    msg = MagicMock(); msg.content = "ocr text"; msg.usage_metadata = {}
+    chain = MagicMock(); chain.batch_as_completed.return_value = [(0, msg)]
+    agent._chain = chain
+    return agent, chain
+
+
+def test_vertex_batch_passes_max_concurrency():
+    from doc2mark.ocr.vertex_ai import VertexAIVisionAgent
+    agent, chain = _agent_with_chain(VertexAIVisionAgent, 32)
+    out = agent.batch_invoke([{"image_data": "x"}])
+    chain.batch_as_completed.assert_called_once()
+    assert chain.batch_as_completed.call_args.kwargs["config"] == {"max_concurrency": 32}
+    assert len(out) == 1
+
+
+def test_vertex_batch_none_means_default():
+    from doc2mark.ocr.vertex_ai import VertexAIVisionAgent
+    agent, chain = _agent_with_chain(VertexAIVisionAgent, None)
+    agent.batch_invoke([{"image_data": "x"}])
+    assert chain.batch_as_completed.call_args.kwargs["config"] is None
+
+
+def test_openai_batch_passes_max_concurrency():
+    from doc2mark.ocr.openai import VisionAgent
+    agent, chain = _agent_with_chain(VisionAgent, 64)
+    agent.batch_invoke([{"image_data": "x"}])
+    assert chain.batch_as_completed.call_args.kwargs["config"] == {"max_concurrency": 64}


### PR DESCRIPTION
## Problem
The `vertex_ai` and `openai` OCR providers OCR **every page-image** through LangChain `batch_as_completed`, but call it with **no config**. Concurrency is therefore locked to LangChain's CPU-tied default thread pool (~12 in a container), and there was **no way to raise it** — `OCRConfig` had no field and `max_workers` is explicitly "Not used". Large scanned PDFs are slow as a result.

**Measured** (Vertex `gemini-3.1-flash-lite`, real worker): 10-page scan = 5.5s, **100-page = ~44s** → effective concurrency ≈ 12, per-page latency ≈ 5s, scaling linearly. A ~1,300-page scan ≈ 10 min purely from the cap.

## Change (backward compatible — default `None` = today's behaviour)
- **`OCRConfig.max_concurrency`** — programmatic cap.
- **`OCR_MAX_CONCURRENCY`** env var — `resolve_max_concurrency()` precedence: explicit `config` value > env > `None`.
- Threaded into `batch_as_completed(config={"max_concurrency": N})` for both `vertex_ai` (`VertexAIVisionAgent`) and `openai` (`VisionAgent`); the batch-start log now reports the active cap.

Raising the cap scales total OCR time down linearly (per-page latency is the floor): `C=32` → ~3,500-page docs in minutes, `C=64` → ~7,000.

## Usage
```python
# programmatic
loader = UnifiedDocumentLoader(ocr_provider="vertex_ai", ...)
# or set the cap on the OCR config / via env:
export OCR_MAX_CONCURRENCY=32
```

## Tests
`tests/test_ocr_concurrency.py`: `resolve_max_concurrency` precedence (explicit / env / invalid / non-positive) + both providers thread the config into `batch_as_completed`. **391 existing tests pass, 9 skipped (API-key integration).**

Version bumped 0.5.1 → 0.5.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)