### PR TITLE
docs: enrich documentation + resync with codebase (tables · contextual OCR · OCR policy)

### DIFF
--- a/docs/api/loader.rst
+++ b/docs/api/loader.rst
@@ -27,9 +27,9 @@ Constructor
        ocr_config=None,
        cache_dir=None,
        ocr_cache=None,
-       model='gpt-4.1',
+       model='gpt-5.4-mini',
        temperature=0,
-       max_tokens=4096,
+       max_tokens=8192,
        max_workers=5,
        prompt_template=PromptTemplate.DEFAULT,
        timeout=30,
@@ -77,8 +77,8 @@ OCR / model tuning
 ~~~~~~~~~~~~~~~~~~~
 
 ``model`` : str
-    Model name. Defaults to ``'gpt-4.1'`` for OpenAI; for ``vertex_ai`` the
-    default ``'gpt-4.1'`` is automatically swapped for a Gemini model.
+    Model name. Defaults to ``'gpt-5.4-mini'`` for OpenAI; for ``vertex_ai`` the
+    default ``'gpt-5.4-mini'`` is automatically swapped for a Gemini model.
 ``temperature`` : float
     Sampling temperature (default ``0``).
 ``max_tokens`` : int

--- a/docs/api/ocr.rst
+++ b/docs/api/ocr.rst
@@ -358,7 +358,7 @@ GPT-4V-class OCR via LangChain. Structured output is produced with
 ``with_structured_output(method="json_schema")``, so the default result carries
 a full :class:`~doc2mark.OCRPage`. Requires an API key
 (``api_key=`` or ``OPENAI_API_KEY``) and the ``doc2mark[ocr]`` extra. The
-default model is ``gpt-4.1``; ``base_url`` (or ``OPENAI_BASE_URL``) targets
+default model is ``gpt-5.4-mini``; ``base_url`` (or ``OPENAI_BASE_URL``) targets
 OpenAI-compatible endpoints. Model knobs follow the precedence **explicit
 constructor argument → ``OCRConfig`` field → built-in default**.
 
@@ -366,7 +366,7 @@ constructor argument → ``OCRConfig`` field → built-in default**.
 
    from doc2mark import OCR
 
-   ocr = OCR("openai", model="gpt-4.1", detail="full")
+   ocr = OCR("openai", model="gpt-5.4-mini", detail="full")
    pages = ocr.read(images, task="document")
    print(pages[0].document.raw.text)
 

--- a/docs/api/schema.rst
+++ b/docs/api/schema.rst
@@ -7,13 +7,15 @@ on ``OCRResult.document``. The schema enforces a hard boundary between two
 concerns:
 
 - **raw** — what is *literally* on the page: a verbatim transcription, any
-  tables, and label/value fields. No inference, no commentary.
+  tables, label/value fields, and additive verbatim indexes (headings, dates,
+  metrics). No inference, no commentary.
 - **interpretation** — the model's *reading* of the page: document type, a
-  short summary, key findings, and confidence. This is the part that requires a
-  language model to reason about the content.
+  short summary, key findings, a knowledge graph, and confidence. This is the
+  part that requires a language model to reason about the content.
 
 This split is the most important idea in the schema. The ``raw`` half is
-always present and is the trustworthy, auditable record of the page. The
+always present and is the trustworthy, auditable record of the page. It is the
+token source for the BM42 sparse index, so everything in it is verbatim. The
 ``interpretation`` half is :data:`None` whenever the model was not asked to —
 or could not — reason about the page, specifically:
 
@@ -21,8 +23,8 @@ or could not — reason about the page, specifically:
 - the provider is non-LLM (e.g. Tesseract, which cannot infer), or
 - the structured-output parse failed and the layer fell back gracefully.
 
-All five models are Pydantic ``BaseModel`` subclasses. Every field is
-defaulted: the LLM providers emit them through LangChain's
+Every model on this page is a Pydantic ``BaseModel`` subclass, and **every
+field is defaulted**: the LLM providers emit them through LangChain's
 ``with_structured_output(method="json_schema")``, and OpenAI strict mode
 requires all properties to be present, so each field must be satisfiable
 without input. Optional fields serialize as ``anyOf: [T, null]``.
@@ -34,12 +36,42 @@ without input. Optional fields serialize as ``anyOf: [T, null]``.
    page back into a single markdown string, which is what powers the
    back-compatible ``OCRResult.text``.
 
+The authoritative, always-current field list for each model is generated below
+directly from the source (defaults, types, and per-field descriptions). The
+prose around each block explains *why* the field exists and how the models fit
+together; the field documentation itself is the rendered docstring.
+
+
+The verbatim / interpretation boundary
+--------------------------------------
+
+The single rule that holds the schema together: **the interpretation layer
+never invents a printed value, and never moves one out of** ``raw``. Anything
+the model claims is *on the page* — a figure axis label, an entity name, a
+relation's subject — is an additive copy of a string that already appears in
+``raw.text``. This keeps the sparse index intact (BM42 reads ``raw.text``)
+while making the same facts queryable as typed structure.
+
+That invariant is mechanically enforced. :func:`~doc2mark.ocr.schema.router_invariants`
+returns a list of violations for a page (empty means OK) and is intended as a
+CI / eval assertion over recorded outputs. It checks, among other things, that
+every verbatim figure string is a substring of ``raw.text``, that every
+``Section.heading`` came from ``raw.headings``, that ``primary_date`` was
+selected from ``raw.dates`` rather than fabricated, that entity names and
+relation subjects/objects are substrings of ``raw.text``, and that withheld
+("illustrative") values appear only on a high-confidence ``screenshot`` page.
+
+When you read a page, treat ``raw`` as ground truth and ``interpretation`` as
+an *additive overlay* that is safe to ignore. Always check
+``page.interpretation is not None`` before reading interpretive fields — with
+``detail="raw"`` or a Tesseract backend it will be ``None``.
+
 
 ``OCRPage`` — the top-level result
 ----------------------------------
 
 One image's structured OCR result. It bundles the always-present ``raw``
-extraction with the optional ``interpretation``.
+extraction with the optional ``interpretation``, and exposes one method.
 
 **Signature**
 
@@ -49,58 +81,15 @@ extraction with the optional ``interpretation``.
        raw: RawExtraction = Field(default_factory=RawExtraction)
        interpretation: Optional[Interpretation] = None
 
-**Fields**
-
-.. list-table::
-   :header-rows: 1
-   :widths: 20 28 22 30
-
-   * - Name
-     - Type
-     - Default
-     - Meaning
-   * - ``raw``
-     - :class:`~doc2mark.ocr.schema.RawExtraction`
-     - empty ``RawExtraction``
-     - Verbatim page content. Always present.
-   * - ``interpretation``
-     - ``Optional[`` :class:`~doc2mark.ocr.schema.Interpretation` ``]``
-     - ``None``
-     - The model's analysis, or ``None`` for ``detail="raw"``, non-LLM
-       providers, and parse-error fallback.
-
-**Methods**
-
 ``to_markdown() -> str``
-    Render a readable markdown view of the page. Prefers structured
-    tables/fields over the flat text dump: it emits ``raw.text`` (stripped)
-    followed by each table — using the table's own ``markdown`` when present,
-    otherwise rendering a markdown grid from ``headers`` + ``rows``. This is the
-    string surfaced as the back-compatible ``OCRResult.text``.
-
-.. note::
-
-   Always check ``page.interpretation is not None`` before reading interpretive
-   fields. With ``detail="raw"`` or a Tesseract backend it will be ``None``.
-
-**Example**
-
-.. code-block:: python
-
-   from doc2mark.ocr.schema import OCRPage
-
-   page: OCRPage = ...  # obtained from an OCRResult.document
-
-   # The raw half is always safe to read.
-   print(page.raw.text)
-
-   # The interpretation half may be absent.
-   if page.interpretation is not None:
-       print(page.interpretation.document_type)  # e.g. "receipt"
-       print(page.interpretation.summary)
-
-   # Collapse to a single markdown string (back-compat OCRResult.text).
-   markdown = page.to_markdown()
+    Render a readable markdown view of the page, used as the back-compatible
+    ``OCRResult.text``. It prefers structured tables/fields over the flat text
+    dump, and renders the additive overlays (real metrics, then figures, then a
+    section outline) degraded-safe. When the interpretation carries a
+    ``page_markdown`` whole-page rendering that verifiably covers the verbatim
+    text, that structured rendering replaces the flat ``raw.text`` dump (with a
+    hidden verbatim tail preserving any uncovered tokens so the index stays
+    complete).
 
 .. autoclass:: doc2mark.ocr.schema.OCRPage
    :members:
@@ -110,123 +99,16 @@ extraction with the optional ``interpretation``.
 ``RawExtraction`` — verbatim page content
 -----------------------------------------
 
-A verbatim transcription of the page. No commentary, no inference. This is the
-``raw`` field of :class:`~doc2mark.ocr.schema.OCRPage`. No analysis belongs
-here.
-
-**Fields**
-
-.. list-table::
-   :header-rows: 1
-   :widths: 22 28 20 30
-
-   * - Name
-     - Type
-     - Default
-     - Meaning
-   * - ``text``
-     - ``str``
-     - ``""``
-     - All visible text, verbatim, in the original language. No analysis.
-   * - ``tables``
-     - ``List[`` :class:`~doc2mark.ocr.schema.Table` ``]``
-     - ``[]``
-     - Tables transcribed from the image.
-   * - ``fields``
-     - ``List[`` :class:`~doc2mark.ocr.schema.KeyValue` ``]``
-     - ``[]``
-     - Label/value pairs for forms & receipts.
-   * - ``detected_language``
-     - ``Optional[str]``
-     - ``None``
-     - The language actually seen on the page (not an echo of config).
-   * - ``has_handwriting``
-     - ``bool``
-     - ``False``
-     - Whether handwriting was detected on the page.
-
-**Example**
-
-.. code-block:: python
-
-   from doc2mark.ocr.schema import RawExtraction, KeyValue
-
-   raw = RawExtraction(
-       text="ACME STORE\nThank you for shopping!",
-       fields=[
-           KeyValue(label="Total", value="$42.50"),
-           KeyValue(label="Date", value="2026-06-27"),
-       ],
-       detected_language="en",
-   )
+A verbatim transcription of the page: no commentary, no inference. This is the
+``raw`` field of :class:`~doc2mark.ocr.schema.OCRPage` and the BM42 token
+source. Alongside the full ``text`` and structured ``tables`` / ``fields``, it
+carries three **additive verbatim indexes** — ``headings``, ``dates``, and
+``metrics`` — each entry of which is a copy of tokens already present in
+``text``, surfaced so an indexer can boost or filter without re-parsing. The
+``metrics`` list holds :class:`~doc2mark.ocr.schema.Metric` objects (typed
+numeric assertions); ``headings`` and ``dates`` are plain verbatim strings.
 
 .. autoclass:: doc2mark.ocr.schema.RawExtraction
-   :members:
-   :show-inheritance:
-
-
-``Interpretation`` — the model's reading
-----------------------------------------
-
-The model's analysis of the page. Never mixed into ``raw``. This is the
-``interpretation`` field of :class:`~doc2mark.ocr.schema.OCRPage`, and is
-``None`` whenever the model was not asked to (or could not) reason.
-
-**Fields**
-
-.. list-table::
-   :header-rows: 1
-   :widths: 22 30 18 30
-
-   * - Name
-     - Type
-     - Default
-     - Meaning
-   * - ``document_type``
-     - ``Literal["document", "table", "form", "receipt", "handwriting",
-       "code", "chart", "photo", "mixed", "blank", "other"]``
-     - ``"other"``
-     - The model's classification of the page.
-   * - ``summary``
-     - ``str``
-     - ``""``
-     - 1-3 sentence description of the content and its purpose.
-   * - ``key_findings``
-     - ``List[str]``
-     - ``[]``
-     - Notable points the model extracted from the page.
-   * - ``reading_order``
-     - ``List[int]``
-     - ``[]``
-     - Block indices in natural reading order, top-to-bottom.
-   * - ``visual_notes``
-     - ``str``
-     - ``""``
-     - Layout, branding, and non-text visual elements.
-   * - ``self_confidence``
-     - ``float`` (``0.0`` ≤ x ≤ ``1.0``)
-     - ``0.0``
-     - The model's own 0..1 confidence estimate.
-   * - ``legibility``
-     - ``Literal["high", "medium", "low"]``
-     - ``"high"``
-     - The model's estimate of how legible the page is.
-
-**Example**
-
-.. code-block:: python
-
-   from doc2mark.ocr.schema import Interpretation
-
-   interpretation = Interpretation(
-       document_type="receipt",
-       summary="Grocery receipt from ACME Store for three items totaling $42.50.",
-       key_findings=["3 line items", "Total: $42.50", "Paid by card"],
-       self_confidence=0.92,
-       legibility="high",
-   )
-
-.. autoclass:: doc2mark.ocr.schema.Interpretation
    :members:
    :show-inheritance:
 
@@ -234,53 +116,15 @@ The model's analysis of the page. Never mixed into ``raw``. This is the
 ``Table`` — a transcribed table
 -------------------------------
 
-A table transcribed verbatim from the image. Used inside the ``tables`` list of
-:class:`~doc2mark.ocr.schema.RawExtraction`.
-
-**Fields**
-
-.. list-table::
-   :header-rows: 1
-   :widths: 20 24 22 34
-
-   * - Name
-     - Type
-     - Default
-     - Meaning
-   * - ``caption``
-     - ``str``
-     - ``""``
-     - Optional caption/title for the table.
-   * - ``headers``
-     - ``List[str]``
-     - ``[]``
-     - Column headers.
-   * - ``rows``
-     - ``List[List[str]]``
-     - ``[]``
-     - Row data, each row a list of cell strings.
-   * - ``markdown``
-     - ``str``
-     - ``""``
-     - Rendered markdown fallback for merged/complex cells the ``headers`` +
-       ``rows`` grid cannot capture. When set,
-       :meth:`~doc2mark.ocr.schema.OCRPage.to_markdown` prefers it over the
-       grid.
-
-**Example**
-
-.. code-block:: python
-
-   from doc2mark.ocr.schema import Table
-
-   table = Table(
-       caption="Items",
-       headers=["Item", "Qty", "Price"],
-       rows=[
-           ["Apples", "2", "$3.00"],
-           ["Bread", "1", "$2.50"],
-       ],
-   )
+A table transcribed verbatim, used inside ``RawExtraction.tables``. The
+preferred representation is ``html``: a clean ``<table>`` that can encode merged
+cells via ``colspan`` / ``rowspan`` (which the flat ``headers`` / ``rows`` grid
+and markdown cannot). The ``html`` value is **sanitized at the model boundary**
+by a field validator (see :func:`~doc2mark.ocr.schema.sanitize_table_html`) to a
+strict table-only allowlist, so the stored string is always safe to embed in
+rendered output. ``illustrative`` flags a demo/mockup table whose values are
+not real data, and ``row_count`` records how many sample rows a header-only
+illustrative table intentionally left untranscribed.
 
 .. autoclass:: doc2mark.ocr.schema.Table
    :members:
@@ -290,37 +134,129 @@ A table transcribed verbatim from the image. Used inside the ``tables`` list of
 ``KeyValue`` — a label/value pair
 ---------------------------------
 
-A single label/value pair, e.g. for forms and receipts. Used inside the
-``fields`` list of :class:`~doc2mark.ocr.schema.RawExtraction`.
-
-**Fields**
-
-.. list-table::
-   :header-rows: 1
-   :widths: 20 20 20 40
-
-   * - Name
-     - Type
-     - Default
-     - Meaning
-   * - ``label``
-     - ``str``
-     - ``""``
-     - The field label, e.g. ``"Total"``.
-   * - ``value``
-     - ``str``
-     - ``""``
-     - The field value, e.g. ``"$42.50"``.
-
-**Example**
-
-.. code-block:: python
-
-   from doc2mark.ocr.schema import KeyValue
-
-   field = KeyValue(label="Total", value="$42.50")
+A single label/value pair, used both inside ``RawExtraction.fields`` (forms,
+receipts) and inside ``Interpretation.definitions`` (term/definition pairs).
+``illustrative`` flags a demo/sample value from a screenshot or mockup region.
 
 .. autoclass:: doc2mark.ocr.schema.KeyValue
+   :members:
+   :show-inheritance:
+
+
+``Metric`` — a typed numeric assertion
+--------------------------------------
+
+A single number printed on the page, captured as a flat, four-field typed fact
+(``label``, ``value``, ``unit``, ``illustrative``). A ``Metric`` is an additive
+view of a number that is *also* present verbatim in ``raw.text`` — never a
+relocation of it. ``value`` is copied exactly as printed (e.g. ``"$4.2B"``,
+``"98.5%"``, ``"< 100 ms"``) and never normalized or computed. Metrics live in
+``RawExtraction.metrics`` and make a number queryable as a typed fact while the
+sparse index keeps reading ``raw.text``.
+
+.. autoclass:: doc2mark.ocr.schema.Metric
+   :members:
+   :show-inheritance:
+
+
+The nested interpretation models
+--------------------------------
+
+The interpretation layer carries a small family of nested models that structure
+a page's *meaning* — figures, hierarchy, and a knowledge graph. They are
+deliberately **shallow** (max nesting depth 4: ``OCRPage`` → ``interpretation``
+→ ``figures`` → ``data_points``), with no recursion, no model-unions, and every
+field defaulted, so they stay fillable under
+``with_structured_output(json_schema)``. They are **additive and BM42-safe**:
+every verbatim string inside them mirrors text already in ``raw.text``, an
+invariant enforced by :func:`~doc2mark.ocr.schema.router_invariants`.
+
+- **Metric** (above) — a typed number, in ``raw.metrics``.
+- **Figure** — one chart / diagram / infographic panel, in
+  ``interpretation.figures``. Its ``kind`` drives which branch fills:
+  quantitative kinds (bar/line/pie/…) fill ``data_points``; structural kinds
+  (flowchart/org_chart/network) fill ``nodes`` + ``edges``; everything else
+  falls back to ``labels`` + ``meaning``. ``meaning`` (and ``trend`` for
+  charts) is the always-attempt interpretive fallback when the typed data can't
+  be read.
+
+  - **DataPoint** — one ``(label, value, series)`` chart reading, flattened to
+    tidy-long form (the deepest leaf, depth 4). All three fields are verbatim
+    copies of printed text; values are never pixel-estimated.
+  - **DiagramNode** — one labelled box / shape / actor in a flowchart, org
+    chart, or network. There is no synthetic id — edges reference nodes by
+    their verbatim ``label``.
+  - **DiagramEdge** — a directed connection between two nodes, referenced by
+    verbatim ``from_label`` / ``to_label`` (each must match a
+    ``DiagramNode.label`` in the same figure).
+
+- **Section** — one heading-delimited region in reading order. Hierarchy is a
+  **flat list plus an integer** ``level`` (never recursive children). Its
+  ``heading`` is a verbatim ``raw.headings`` entry; ``summary`` and
+  ``key_points`` are paraphrase.
+- **Entity** — a typed named entity (person / org / product / location /
+  concept / other) with a ``salience`` ranking. Its ``name`` is verbatim in
+  ``raw.text``; dates, money, and KPIs are *not* entities — they live in
+  ``raw.dates`` / ``raw.metrics``.
+- **Relation** — a knowledge triple (``subject`` / ``relation`` / ``object``)
+  for a claim **explicitly stated** on the page, with an ``evidence`` quote that
+  makes it falsifiable. ``subject`` and ``object`` are substrings of
+  ``raw.text``; the predicate and evidence may paraphrase.
+
+Finally, the interpretation can carry a ``page_markdown`` string: a clean,
+structured Markdown re-layout of a whole-page image render. It is filled only
+when explicitly instructed (slide / scan image-strategy pages) and, when filled,
+must cover every word, number, and CJK character from ``raw.text`` verbatim — it
+re-flows existing content into a readable document, it never adds or removes any.
+
+.. autoclass:: doc2mark.ocr.schema.Figure
+   :members:
+   :show-inheritance:
+
+.. autoclass:: doc2mark.ocr.schema.DataPoint
+   :members:
+   :show-inheritance:
+
+.. autoclass:: doc2mark.ocr.schema.DiagramNode
+   :members:
+   :show-inheritance:
+
+.. autoclass:: doc2mark.ocr.schema.DiagramEdge
+   :members:
+   :show-inheritance:
+
+.. autoclass:: doc2mark.ocr.schema.Section
+   :members:
+   :show-inheritance:
+
+.. autoclass:: doc2mark.ocr.schema.Entity
+   :members:
+   :show-inheritance:
+
+.. autoclass:: doc2mark.ocr.schema.Relation
+   :members:
+   :show-inheritance:
+
+
+``Interpretation`` — the model's reading
+----------------------------------------
+
+The model's analysis of the page, never mixed into ``raw``. This is the
+``interpretation`` field of :class:`~doc2mark.ocr.schema.OCRPage`, and is
+``None`` whenever the model was not asked to (or could not) reason.
+
+It classifies the page via ``document_type`` (one of 16 values: ``document``,
+``table``, ``form``, ``receipt``, ``handwriting``, ``code``, ``chart``,
+``photo``, ``screenshot``, ``diagram``, ``infographic``, ``logo``, ``stamp``,
+``mixed``, ``blank``, ``other``) and carries the retrieval / comprehension
+anchors and overlays described above — ``page_title``, ``primary_message``,
+``keywords``, the nested ``figures`` / ``sections`` / ``typed_entities`` /
+``relations``, plus ``column_layout``, ``page_role``, ``primary_date``,
+``action_items``, ``definitions``, ``content_fidelity``, ``self_confidence``,
+``legibility``, and ``page_markdown``. See the rendered field list for the exact
+defaults and meanings.
+
+.. autoclass:: doc2mark.ocr.schema.Interpretation
    :members:
    :show-inheritance:
 
@@ -334,7 +270,7 @@ the verbatim ``raw`` half and the model's ``interpretation`` half.
 .. code-block:: python
 
    from doc2mark.ocr.schema import (
-       OCRPage, RawExtraction, Interpretation, Table, KeyValue,
+       OCRPage, RawExtraction, Interpretation, Table, KeyValue, Metric,
    )
 
    page = OCRPage(
@@ -363,6 +299,8 @@ the verbatim ``raw`` half and the model's ``interpretation`` half.
                KeyValue(label="Store", value="ACME STORE"),
                KeyValue(label="Total", value="$9.50"),
            ],
+           headings=["ACME STORE"],
+           metrics=[Metric(label="Total", value="$9.50")],
            detected_language="en",
            has_handwriting=False,
        ),
@@ -373,6 +311,7 @@ the verbatim ``raw`` half and the model's ``interpretation`` half.
                "with a total of $9.50."
            ),
            key_findings=["3 line items", "Total: $9.50"],
+           primary_message="Three grocery items were purchased for $9.50.",
            self_confidence=0.94,
            legibility="high",
        ),

--- a/docs/contextual_ocr.rst
+++ b/docs/contextual_ocr.rst
@@ -1,0 +1,198 @@
+Contextual OCR strategy
+=======================
+
+When doc2mark OCRs a PDF page in isolation, the model sees only that one image.
+It has no way to know how a term was spelled two pages earlier, what language the
+surrounding document is written in, or whether a screenshot of round numbers is a
+real financial table or an illustrative product mock-up. The **contextual OCR
+strategy** fixes this: when transcribing the content on page *k*, doc2mark can
+attach a small PDF of the neighboring pages ``{k-1, k, k+1}`` as *context* -- not
+as something to transcribe -- so the model can anchor terminology, proper names,
+and language continuity against the document's own neighbors.
+
+This produces more consistent transcriptions (the same term spelled the same way
+across pages), keeps the output in the document's own language, and gives the
+self-routing AUTO prompt enough signal to judge a host document's purpose before
+it applies any non-verbatim policy.
+
+The idea
+--------
+
+The transcription target never changes: the page **image** is, and remains, the
+sole thing the model transcribes. The context PDF rides alongside it as a
+separate, clearly-labeled attachment. Both LLM providers prepend a strict
+instruction (``_CONTEXT_PDF_INSTRUCTION`` in ``doc2mark/ocr/base.py``) telling
+the model:
+
+   The IMAGE above is the PRIMARY and ONLY target to transcribe. The attached PDF
+   contains the neighboring pages (previous/current/next) of the same document and
+   is provided STRICTLY as CONTEXT for terminology, names, and language
+   continuity. Do NOT transcribe, summarize, or quote the PDF. [...] Transcribe
+   ONLY what is visibly present in the image, and respond in the document's own
+   language.
+
+A second clause (``_ROUTER_CONFIDENCE_CLAUSE``) is appended so the AUTO router
+uses the neighbors *only* to judge the host document's purpose, and may apply its
+``describe``/``screenshot`` policies **only** when its ``self_confidence`` is at
+least ``0.7`` and legibility is ``"high"`` -- otherwise it falls back to verbatim
+transcription. Context augments the model's judgement; it never licenses dropping
+real text.
+
+The ``context_pages`` tiers
+---------------------------
+
+The feature is controlled by a single field on
+:class:`~doc2mark.ocr.OCRConfig`::
+
+   context_pages: int = 0
+
+This integer is a **scope tier**, not a window size -- the window is always fixed
+at ``{k-1, k, k+1}``. The three tiers are:
+
+``context_pages = 0``
+   Off (the default). Zero behavior change -- the off path is byte-identical to a
+   build without the feature.
+
+``context_pages = 1``
+   Attach context to **whole-page renders** only (one PDF upload per rendered
+   image page). This is the image-strategy route, where a page is mostly pictures
+   and the whole page is rasterized and OCR'd.
+
+``context_pages = 2``
+   Renders **and** non-decorative embedded images. Opt-in; adds an upload per
+   embedded figure that survives the decorative filter. More uploads, more cost.
+
+The tier is resolved once, from the OCR instance's config, in the PDF loader::
+
+   self._context_tier = int(getattr(cfg, "context_pages", 0) or 0)
+
+and gates context building per image in ``_collect_all_images``: whole-page
+renders pass ``self._context_tier >= 1``; embedded images pass
+``self._context_tier >= 2``.
+
+How the window PDF is built
+---------------------------
+
+``_build_window_pdf(k)`` (in
+``doc2mark/pipelines/pymupdf_advanced_pipeline.py``) constructs the context PDF
+for page index ``k``:
+
+- **Fixed, clamped window.** It copies pages ``a = max(0, k-1)`` through
+  ``b = min(n-1, k+1)`` inclusive into a fresh PDF with PyMuPDF's
+  ``insert_pdf``. At the document edges the window simply clamps: page ``0``
+  yields ``{0, 1}``, the last page yields ``{n-2, n-1}``, and a single-page
+  document yields ``{0}``. It is therefore never more than three pages.
+
+- **Compressed.** The PDF is serialized with ``tobytes(deflate=True,
+  garbage=3)`` to compress streams and drop orphaned objects.
+
+- **Per-page de-duplicated.** The result is cached in a small LRU
+  (``_WINDOW_CACHE_MAXLEN = 4``) keyed by page index, so the window for a given
+  page is built at most once even though several embedded images on that page
+  share it, and overlapping windows on adjacent pages do not rebuild work.
+
+- **Size-guarded.** If the compressed PDF exceeds
+  ``_CONTEXT_PDF_MAX_BYTES`` (18 MB -- chosen to stay under Gemini's ~20 MB
+  inline request cap), the function logs a warning and returns ``None``. Any
+  failure to build the PDF also returns ``None``. Callers treat ``None`` as "no
+  context" and OCR the image normally, so the feature degrades gracefully and
+  never blocks a page.
+
+The output is **raw base64** (no ``data:`` URI prefix), which makes it
+provider-independent -- each provider wraps it in its own attachment format.
+
+How each provider attaches the context PDF
+------------------------------------------
+
+The per-image context base64 travels positionally alongside the image bytes as a
+``context_pdfs`` list, and the loader only sets that keyword when at least one
+image in the batch actually carries context (keeping the off-default path
+unchanged). Each provider then attaches it as a **context-only** part next to the
+image in the same ``HumanMessage``.
+
+**OpenAI** (``doc2mark/ocr/openai.py``) appends the instruction text and a nested
+``file`` block:
+
+.. code-block:: python
+
+   content.append({
+       "type": "file",
+       "file": {
+           "filename": "context.pdf",
+           "file_data": f"data:application/pdf;base64,{context_pdf}",
+       },
+   })
+
+This is attached **only** when the PDF is present *and* the model can ingest a
+PDF part. PDF capability is gated by ``_model_supports_pdf`` against the prefixes
+``gpt-4o``, ``gpt-4.1``, ``gpt-5``, and ``o1`` -- so the default model,
+``gpt-5.4-mini``, qualifies, while a non-PDF model silently skips the attachment
+instead of 400-ing.
+
+**Gemini / Vertex AI** (``doc2mark/ocr/vertex_ai.py``) appends the same
+instruction text and a ``media`` part carrying the raw base64:
+
+.. code-block:: python
+
+   content.append({
+       "type": "media",
+       "mime_type": "application/pdf",
+       "data": context_pdf,
+   })
+
+In both providers the image stays the first and only transcription target; the
+PDF is an extra part the model is told to read for context only.
+
+It augments -- it never replaces the verbatim layer
+----------------------------------------------------
+
+Context is purely additive. The deterministic, rule-based text and table layer
+that doc2mark extracts from a text-authoritative PDF is always preserved
+**verbatim** for the BM42 RAG flow -- the context PDF only rides on the OCR calls
+that handle page renders (tier 1) and embedded figures (tier 2). Turning the
+feature on does not alter, paraphrase, or re-derive any text that the rule-based
+layer already captured; it only sharpens what the vision model produces for the
+images it was already going to OCR.
+
+Enabling it
+-----------
+
+Because context is built from neighboring PDF pages, it applies to **PDF sources
+only**, and you enable it by passing an :class:`~doc2mark.ocr.OCRConfig` with
+``context_pages`` set through the loader:
+
+.. code-block:: python
+
+   from doc2mark import UnifiedDocumentLoader
+   from doc2mark.ocr.base import OCRConfig
+
+   loader = UnifiedDocumentLoader(
+       ocr_provider="openai",                 # gpt-5.4-mini is PDF-capable
+       ocr_config=OCRConfig(context_pages=1),  # context on whole-page renders
+   )
+
+   doc = loader.load(
+       "scanned-report.pdf",
+       extract_images=True,
+       ocr_images=True,
+   )
+
+Set ``context_pages=2`` to also attach context to non-decorative embedded
+figures. Use Gemini/Vertex AI or a PDF-capable OpenAI model so the attachment is
+actually consumed.
+
+Cost and payload, honestly
+--------------------------
+
+Context is not free. Every OCR call that carries it uploads an extra PDF -- up to
+three pages -- in addition to the page image:
+
+- At **tier 1**, that is one context PDF per rendered image page.
+- At **tier 2**, it is additionally one per surviving embedded figure, so a page
+  with several figures multiplies the uploads (they share the same cached window
+  PDF, but each call still ships it).
+
+The window PDF is capped at 18 MB and compressed, but it still adds tokens and
+bytes to every call, which means more latency and higher per-call cost. Enable it
+when cross-page consistency, naming, and language continuity matter; leave it at
+the default ``0`` when they do not.

--- a/docs/formats.rst
+++ b/docs/formats.rst
@@ -1,0 +1,259 @@
+Supported formats & how each is handled
+=======================================
+
+doc2mark recognises an input file by its **extension** and dispatches it to a
+dedicated processor. Every processor produces the same
+:class:`~doc2mark.ProcessedDocument` (Markdown ``content`` plus
+:class:`~doc2mark.DocumentMetadata`), so the format you feed in never changes
+how you consume the result.
+
+Two ideas are worth keeping in mind while reading this page:
+
+- **Rule-based extraction is the default.** Office, PDF, text, markup, and email
+  files are parsed structurally (no model calls), so they need **no OCR
+  credentials**. OCR is *opt-in*: it only runs when you pass
+  ``extract_images=True`` together with ``ocr_images=True`` (and only for the
+  formats that carry images). See :doc:`/ocr_policy` for exactly how that
+  decision is made, and :doc:`/ocr` for configuring a provider.
+- **Legacy Office formats need LibreOffice.** ``.doc``, ``.xls``, ``.ppt``,
+  ``.pps``, and ``.rtf`` are converted to their modern equivalents by a local
+  LibreOffice (``soffice``) install before parsing.
+
+How a format is detected
+------------------------
+
+Detection is extension-based (case-insensitive). The loader strips the leading
+dot, lowercases it, and matches it against :class:`~doc2mark.DocumentFormat`.
+Two aliases are normalised: ``.htm`` maps to ``HTML`` and ``.markdown`` maps to
+``MARKDOWN`` (whose canonical extension value is ``"md"``). An unknown extension
+raises :class:`~doc2mark.UnsupportedFormatError`.
+
+.. code-block:: python
+
+   from doc2mark import UnifiedDocumentLoader
+
+   loader = UnifiedDocumentLoader(ocr_provider=None)  # no OCR needed
+   print(loader.supported_formats)   # ['docx', 'xlsx', 'pptx', 'doc', ...]
+
+Extension → processor → OCR
+---------------------------
+
+The "OCR" column reflects whether OCR can ever be involved. Where it says
+*Optional*, OCR runs only when both ``extract_images=True`` and
+``ocr_images=True`` are passed **and** an OCR provider is configured; otherwise
+the file is handled purely by rule-based extraction. Where it says *Never*, the
+processor never calls OCR regardless of those flags.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 26 22 18 34
+
+   * - Extensions
+     - Processor
+     - OCR
+     - Extraction approach
+   * - ``.docx``, ``.pptx``, ``.xlsx``
+     - ``OfficeProcessor``
+     - Optional
+     - Rule-based OOXML parsing (advanced Office pipeline). Embedded images can
+       be extracted as base64 and optionally OCR'd.
+   * - ``.pdf``
+     - ``PDFProcessor``
+     - Optional
+     - Rule-based text/table extraction via the advanced PDF pipeline
+       (PyMuPDF fallback). Page/figure images can be extracted and optionally
+       OCR'd.
+   * - ``.doc``, ``.ppt``, ``.pps``, ``.xls``, ``.rtf``
+     - ``LegacyProcessor``
+     - Optional
+     - LibreOffice converts to ``.docx`` / ``.pptx`` / ``.xlsx``, then the
+       Office processor runs. **Requires LibreOffice.**
+   * - ``.png``, ``.jpg``, ``.jpeg``, ``.webp``, ``.tiff``, ``.tif``,
+       ``.bmp``, ``.gif``, ``.heic``, ``.heif``, ``.avif``
+     - ``ImageProcessor``
+     - Optional
+     - Pillow reads the image; text content comes from OCR when requested.
+       ``.heic`` / ``.heif`` need the ``pillow-heif`` extra.
+   * - ``.txt``, ``.csv``, ``.tsv``, ``.json``, ``.jsonl``
+     - ``TextProcessor``
+     - Never
+     - Plain-text and structured-data parsing only.
+   * - ``.html``, ``.htm``, ``.xml``, ``.md``, ``.markdown``
+     - ``MarkupProcessor``
+     - Never
+     - HTML/XML/Markdown to Markdown conversion.
+   * - ``.eml``
+     - ``EmailProcessor``
+     - Never
+     - RFC 822 header + body extraction (optional; see below).
+
+Office formats (DOCX, PPTX, XLSX)
+---------------------------------
+
+Modern Office files are parsed by ``OfficeProcessor`` through the advanced
+Office pipeline. Paragraphs, headings, lists, and tables are converted to
+Markdown with page / slide / sheet markers preserved. Complex tables with
+merged cells respect the loader's ``table_style`` (``'minimal_html'`` by
+default, or ``'markdown_grid'`` / ``'styled_html'``).
+
+- **Images.** With ``extract_images=True`` the embedded media is returned as
+  base64 in ``ProcessedDocument.images``; adding ``ocr_images=True`` runs the
+  configured OCR provider over those images (batched).
+- **Image-dominant docs.** A ``.docx`` / ``.pptx`` that is mostly pictures with
+  little real text (decided from the OOXML structure, no rendering) is routed
+  through the PDF image strategy: LibreOffice renders it to PDF, the PDF
+  processor OCRs whole pages, and the original Office identity is restored in the
+  metadata (``metadata.extra['routed_via'] == 'pdf'``). This route is gated on
+  OCR being requested and silently falls back to native parsing if anything
+  (including a missing LibreOffice) is unavailable. ``.xlsx`` never routes this
+  way.
+
+.. code-block:: python
+
+   loader = UnifiedDocumentLoader(ocr_provider=None)
+   doc = loader.load("report.docx")
+   print(doc.metadata.format)        # DocumentFormat.DOCX
+   print(doc.metadata.page_count)
+
+If the advanced pipeline is unavailable, the processor falls back to basic
+python-docx / openpyxl / python-pptx parsing.
+
+PDF
+---
+
+``PDFProcessor`` uses the advanced PDF pipeline (``pdf_to_simple_json`` →
+``pdf_to_markdown``) to extract text and tables; table extraction is always on.
+The ``ocr_images`` flag is mapped to the pipeline's ``use_ocr`` and only takes
+effect together with ``extract_images=True``. When the advanced pipeline cannot
+be imported, the processor falls back to PyMuPDF (``fitz``): per-page text
+extraction, and — if OCR is enabled — rendering each page at 300 DPI and OCRing
+pages that have no text layer.
+
+.. code-block:: python
+
+   loader = UnifiedDocumentLoader(ocr_provider="openai", api_key="sk-...")
+   doc = loader.load("scanned.pdf", extract_images=True, ocr_images=True)
+   print(doc.content)
+
+Legacy Office formats (DOC, PPT, PPS, XLS, RTF)
+-----------------------------------------------
+
+``LegacyProcessor`` shells out to a local LibreOffice (``soffice``) install to
+convert each legacy file to a modern container, then hands the result to
+``OfficeProcessor``:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 30 40
+
+   * - Source extension
+     - Converted to
+     - Backing processor
+   * - ``.doc``
+     - ``.docx``
+     - Office (Word)
+   * - ``.rtf``
+     - ``.docx``
+     - Office (Word)
+   * - ``.ppt``
+     - ``.pptx``
+     - Office (PowerPoint)
+   * - ``.pps``
+     - ``.pptx``
+     - Office (PowerPoint)
+   * - ``.xls``
+     - ``.xlsx``
+     - Office (Excel)
+
+The original format and filename are restored in the metadata, and the
+conversion is recorded under ``metadata.extra`` (``converted_from`` /
+``converted_to``). If LibreOffice is not found, processing raises
+:class:`~doc2mark.ProcessingError` with installation guidance. Because the
+output is a real Office document, the same image extraction / OCR options apply.
+
+Images (PNG, JPG, JPEG, WEBP, TIFF, TIF, BMP, GIF, HEIC, HEIF, AVIF)
+--------------------------------------------------------------------
+
+``ImageProcessor`` opens the file with Pillow and writes a small Markdown header
+describing the image (format, dimensions, mode, size). For standalone images the
+only way to recover text is OCR:
+
+- ``ocr_images=True`` (with a configured provider) transcribes the image; the
+  text is appended under an *OCR Extracted Text* section and mirrored in
+  ``json_content`` as a ``text:image_description`` entry.
+- ``extract_images=True`` (the default for this processor) also returns the
+  image re-encoded as PNG base64 in ``ProcessedDocument.images``.
+
+``.heic`` / ``.heif`` decoding requires the optional ``pillow-heif`` package; if
+it is not installed those formats simply cannot be opened.
+
+.. code-block:: python
+
+   loader = UnifiedDocumentLoader(ocr_provider="openai", api_key="sk-...")
+   doc = loader.load("receipt.jpg", ocr_images=True)
+   print(doc.content)
+
+Text & data (TXT, CSV, TSV, JSON, JSONL)
+----------------------------------------
+
+``TextProcessor`` handles plain-text and structured-data files entirely with the
+standard library — **no OCR, ever**:
+
+- ``.txt`` — read as text (``encoding`` defaults to ``utf-8``); all-caps short
+  lines are promoted to Markdown headings.
+- ``.csv`` — the delimiter is auto-detected with :class:`csv.Sniffer` (override
+  with the ``delimiter`` argument) and rows become a Markdown table.
+- ``.tsv`` — same as CSV with a tab delimiter.
+- ``.json`` — parsed and rendered as nested Markdown; metadata records the
+  top-level ``data_type`` and ``item_count``.
+- ``.jsonl`` — each non-empty line is parsed as one record; invalid lines are
+  skipped with a warning, and each record is rendered under its own heading.
+
+.. code-block:: python
+
+   loader = UnifiedDocumentLoader(ocr_provider=None)
+   doc = loader.load("data.csv", delimiter=";")
+   print(doc.metadata.row_count, doc.metadata.column_count)
+
+Markup (HTML, XML, Markdown)
+----------------------------
+
+``MarkupProcessor`` converts markup to Markdown without any OCR:
+
+- **HTML / HTM** — parsed with BeautifulSoup and converted via ``markdownify``
+  (ATX headings, ``-`` bullets) when available, falling back to a built-in
+  ``SimpleHTMLToMarkdown`` parser. Title, word, link, and image counts are
+  recorded in the metadata.
+- **XML** — parsed safely with ``defusedxml`` and rendered as a heading tree
+  (tags → headings, attributes → bullet lists, text/tail preserved). Metadata
+  captures ``root_tag`` and ``element_count``.
+- **Markdown (.md / .markdown)** — passed through largely as-is. Leading YAML
+  front-matter is parsed (when PyYAML is installed) into ``metadata.frontmatter``,
+  and heading / link / image counts are computed.
+
+Email (EML)
+-----------
+
+``EmailProcessor`` reads RFC 822 ``.eml`` files with the standard-library
+``email`` package — no OCR. It extracts the ``From``, ``To``, ``Cc``,
+``Subject``, and ``Date`` headers and the best body representation, preferring a
+``text/plain`` part and otherwise converting the ``text/html`` part to Markdown
+with the same ``SimpleHTMLToMarkdown`` converter used for web pages. The default
+Markdown rendering uses the subject as the top-level heading followed by the
+remaining headers and the body; ``TEXT`` and ``JSON`` output formats are also
+supported.
+
+.. note::
+
+   ``.eml`` support is registered only when the email module and the
+   ``DocumentFormat.EML`` member are both present, so the rest of the loader
+   keeps working even in builds without it.
+
+Choosing whether OCR runs
+-------------------------
+
+For every format above, plain extraction happens with no credentials. OCR is a
+deliberate add-on you enable per call via ``extract_images`` / ``ocr_images``
+(images, Office, PDF, and image-dominant routing). The full decision
+procedure — when an OCR provider is built, when it is invoked, and what happens
+without credentials — is documented in :doc:`/ocr_policy`.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,7 +14,11 @@ OCR providers are initialized only when OCR is requested.
 
    quickstart
    cli
+   formats
    ocr
+   ocr_policy
+   tables
+   contextual_ocr
    caching
 
 .. toctree::

--- a/docs/ocr.rst
+++ b/docs/ocr.rst
@@ -2,31 +2,40 @@ OCR
 ===
 
 doc2mark includes an AI-powered OCR layer that returns **structured output** by
-default. OCR providers are optional -- the package can process normal text
-documents without any OCR credentials.
+default. OCR providers are optional -- the package processes normal text
+documents without any OCR credentials; OCR is only invoked when an image needs
+to be read.
+
+This page is a task-oriented guide to *using* OCR. The full result schema (every
+field of every model) lives on :doc:`/api/schema`, and the exhaustive facade /
+provider / config reference lives on :doc:`/api/ocr`.
+
 
 The OCR facade
 --------------
 
-The :class:`~doc2mark.ocr.OCR` class is the recommended entry point:
+The :class:`~doc2mark.ocr.OCR` class is the one entry point you are expected to
+touch. Construct it with a provider name, then call
+:meth:`~doc2mark.ocr.OCR.read` (a batch) or :meth:`~doc2mark.ocr.OCR.read_one`
+(a single image):
 
 .. code-block:: python
 
    from doc2mark import OCR
 
-   ocr = OCR("openai")                        # creds from OPENAI_API_KEY env var
+   ocr = OCR("openai")                         # creds from OPENAI_API_KEY env var
    results = ocr.read([image_bytes])           # List[bytes] -> List[OCRResult]
    r = results[0]
 
    r.document.raw.text                         # verbatim transcription
-   r.document.raw.tables                       # list of Table objects
-   r.document.raw.fields                       # list of KeyValue pairs
-   r.document.interpretation.summary           # model's summary
-   r.document.interpretation.document_type     # "receipt", "form", ...
+   r.document.raw.tables                       # list of Table objects (html / headers+rows)
+   r.document.raw.fields                       # list of KeyValue label/value pairs
+   r.document.interpretation.summary           # model's summary (None for detail="raw")
+   r.document.interpretation.document_type     # e.g. "receipt", "form", "chart"
 
    r.text                                      # back-compat rendered markdown
 
-For a single image use :meth:`~doc2mark.ocr.OCR.read_one`:
+For a single image:
 
 .. code-block:: python
 
@@ -36,126 +45,114 @@ Constructor signature::
 
    OCR(provider="openai", *, api_key=None, **config_kwargs)
 
-All keyword arguments are forwarded to :class:`~doc2mark.ocr.base.OCRConfig`.
+``provider`` is one of ``"openai"``, ``"vertex_ai"``, ``"gemini"``, or
+``"tesseract"`` (or an :class:`~doc2mark.ocr.OCRProvider` member). All keyword
+arguments are forwarded to :class:`~doc2mark.ocr.OCRConfig`; a string ``task`` is
+coerced to the matching :class:`~doc2mark.ocr.Task` member and ``detail`` is
+validated to ``"raw"`` / ``"full"`` eagerly, so a bad value raises ``ValueError``
+immediately.
 
-Structured output schema
+
+What a result looks like
 ------------------------
 
-Every result carries an :class:`~doc2mark.ocr.schema.OCRPage` on
-``result.document``. It enforces a hard boundary between **raw extraction**
-(verbatim, no inference) and **interpretation** (the model's analysis).
+Every call returns one :class:`~doc2mark.ocr.OCRResult` per input image, in input
+order. Its ``text`` is always populated (rendered markdown, for back-compat) and
+``document`` carries the structured :class:`~doc2mark.ocr.schema.OCRPage` for the
+LLM providers (and for Tesseract, with an empty ``interpretation``), or ``None``
+for the legacy free-form path.
+
+``OCRPage`` enforces a hard boundary between **raw extraction** (verbatim, no
+inference -- the trustworthy record of the page) and **interpretation** (the
+model's analysis, which may be ``None``):
 
 .. code-block:: python
 
-   OCRPage(
-       raw=RawExtraction(
-           text="WHOLE FOODS MARKET\n123 Main St\nOrganic Bananas  $2.49\n...",
-           tables=[Table(
-               caption="Line items",
-               headers=["Item", "Price"],
-               rows=[["Organic Bananas", "$2.49"], ["Almond Milk", "$4.99"]],
-           )],
-           fields=[
-               KeyValue(label="Merchant", value="Whole Foods Market"),
-               KeyValue(label="Subtotal", value="$7.48"),
-               KeyValue(label="Tax", value="$0.62"),
-               KeyValue(label="Total", value="$8.10"),
-           ],
-           detected_language="en",
-           has_handwriting=False,
-       ),
-       interpretation=Interpretation(
-           document_type="receipt",
-           summary="A grocery receipt for two items totaling $8.10 including tax.",
-           key_findings=["2 line items", "Total $8.10", "Tax rate ~8.3%"],
-           self_confidence=0.93,
-           legibility="high",
-       ),
-   )
+   r = ocr.read_one(receipt_png, task="receipt")
+   page = r.document                           # an OCRPage
 
-``raw`` fields
-~~~~~~~~~~~~~~
+   # raw -- always present, always verbatim
+   page.raw.text                               # all visible text, original language
+   page.raw.tables                             # List[Table]
+   page.raw.fields                             # List[KeyValue]
+   page.raw.headings                           # List[str], verbatim heading lines
+   page.raw.dates                              # List[str], verbatim dates
+   page.raw.metrics                            # List[Metric], typed numeric facts
+   page.raw.detected_language                  # language actually seen
+   page.raw.has_handwriting                    # bool
 
-.. list-table::
-   :header-rows: 1
-   :widths: 25 75
+   # interpretation -- guard for None first
+   if page.interpretation is not None:
+       page.interpretation.document_type       # 16-way classification (below)
+       page.interpretation.summary
+       page.interpretation.self_confidence     # 0.0 .. 1.0
+       page.interpretation.legibility          # "high" / "medium" / "low"
 
-   * - Field
-     - Description
-   * - ``text``
-     - All visible text, verbatim, in the original language.
-   * - ``tables``
-     - List of :class:`~doc2mark.ocr.schema.Table` (``headers``, ``rows``, ``caption``, ``markdown``).
-   * - ``fields``
-     - List of :class:`~doc2mark.ocr.schema.KeyValue` label/value pairs (forms, receipts).
-   * - ``detected_language``
-     - Language actually seen on the page (not an echo of config).
-   * - ``has_handwriting``
-     - Whether handwriting was detected.
+``interpretation`` is ``None`` when ``detail="raw"`` was requested, for the
+Tesseract provider, or when a structured-output parse failed and the layer fell
+back gracefully. **Always check ``page.interpretation is not None`` before
+reading interpretive fields.**
 
-``interpretation`` fields
-~~~~~~~~~~~~~~~~~~~~~~~~~
+``document_type`` is one of 16 values: ``document``, ``table``, ``form``,
+``receipt``, ``handwriting``, ``code``, ``chart``, ``photo``, ``screenshot``,
+``diagram``, ``infographic``, ``logo``, ``stamp``, ``mixed``, ``blank``,
+``other``.
 
-``interpretation`` is ``None`` when ``detail="raw"``, for Tesseract, or on
-parse-error fallback.
+Beyond the basics shown above, ``raw`` also carries the additive verbatim indexes
+``headings`` / ``dates`` / ``metrics``, and ``interpretation`` carries retrieval
+and knowledge-graph anchors -- ``content_fidelity``, ``page_title``,
+``primary_message``, ``keywords``, ``figures`` (List[:class:`~doc2mark.ocr.schema.Figure`]),
+``sections`` (List[:class:`~doc2mark.ocr.schema.Section`]), ``typed_entities``
+(List[:class:`~doc2mark.ocr.schema.Entity`]), ``relations``
+(List[:class:`~doc2mark.ocr.schema.Relation`]), ``column_layout``, ``page_role``,
+``primary_date``, ``action_items``, ``definitions``, and ``page_markdown``. See
+:doc:`/api/schema` for the authoritative, always-current field list of every
+model.
 
-.. list-table::
-   :header-rows: 1
-   :widths: 25 75
-
-   * - Field
-     - Description
-   * - ``document_type``
-     - One of: ``document``, ``table``, ``form``, ``receipt``, ``handwriting``, ``code``, ``chart``, ``photo``, ``mixed``, ``blank``, ``other``.
-   * - ``summary``
-     - 1--3 sentence description of the content.
-   * - ``key_findings``
-     - Notable observations as a list of strings.
-   * - ``self_confidence``
-     - Model's own 0--1 confidence estimate.
-   * - ``legibility``
-     - ``"high"``, ``"medium"``, or ``"low"``.
-   * - ``visual_notes``
-     - Layout, branding, and non-text visual elements.
-   * - ``reading_order``
-     - Block indices in natural reading order.
 
 Tasks
 -----
 
-Tasks replace the old ``PromptTemplate`` variants. Set a task at construction
-time or override per call:
+A :class:`~doc2mark.ocr.Task` names the *intent* of an image; the intent selects a
+short, schema-aligned instruction that steers the model toward the right ``raw``
+fields. Set a task at construction time or override it per call:
 
 .. code-block:: python
 
    ocr = OCR("openai", task="receipt")          # all calls default to receipt
    results = ocr.read(images, task="table")     # per-call override
 
-For mixed batches, assign a task per image:
+For mixed batches, assign one task per image with ``tasks`` (its length must equal
+``len(images)``; it wins over the single ``task``):
 
 .. code-block:: python
 
    results = ocr.read(images, tasks=["table", "receipt", "handwriting"])
 
-Available :class:`~doc2mark.ocr.base.Task` values:
+Available task values:
 
-- ``auto`` -- general-purpose (default)
-- ``table`` -- tabular data
-- ``document`` -- text documents with headings and lists
+- ``auto`` -- general-purpose self-routing default (classify-then-act)
+- ``table`` -- tabular data (reproduced as HTML in ``Table.html``)
+- ``document`` -- prose with headings, lists, reading order
 - ``form`` -- form label/value extraction
 - ``receipt`` -- receipts and invoices
 - ``handwriting`` -- handwritten text
 - ``code`` -- source code or terminal output
 
+``language`` is intentionally **not** a task -- it is a separate config field
+(and a per-call ``read(..., language=...)`` override), so there is no
+"multilingual" task.
+
+
 Raw and legacy modes
 --------------------
 
-Skip the interpretation pass to save tokens (10--30% fewer output tokens):
+Skip the interpretation pass to save output tokens:
 
 .. code-block:: python
 
    results = ocr.read(images, detail="raw")
-   # r.document.interpretation is None; r.document.raw is still populated
+   # r.document.interpretation is None; r.document.raw is still fully populated
 
 Disable structured output entirely for free-form markdown (legacy behaviour):
 
@@ -164,13 +161,41 @@ Disable structured output entirely for free-form markdown (legacy behaviour):
    results = ocr.read(images, structured=False)
    # r.text contains free-form markdown; r.document is None
 
+Both ``detail`` and ``structured`` can also be set once on the facade
+(``OCR("openai", detail="raw")``) and overridden per call.
+
+
+Tables
+------
+
+Each transcribed table is a :class:`~doc2mark.ocr.schema.Table`. Its preferred
+representation is the ``html`` field: a clean ``<table>`` that can encode merged
+cells via ``colspan`` / ``rowspan`` -- something the flat ``headers`` / ``rows``
+grid cannot. The flat grid and a ``markdown`` fallback remain populated for simple
+machine-readable access.
+
+.. code-block:: python
+
+   for table in r.document.raw.tables:
+       print(table.html)                        # merged-cell-aware HTML (preferred)
+       print(table.headers, table.rows)         # best-effort flat view
+       if table.illustrative:                   # demo/mockup values, not real data
+           print("sample rows omitted:", table.row_count)
+
+See :doc:`/tables` for how tables flow through the loader and into the final
+document.
+
+
 Providers
 ---------
 
 OpenAI
 ~~~~~~
 
-Uses GPT-4.1 vision. Requires ``OPENAI_API_KEY``.
+GPT vision via LangChain. Structured output is produced with
+``with_structured_output(method="json_schema")``. Requires ``OPENAI_API_KEY``
+(or ``api_key=``) and the ``doc2mark[ocr]`` extra. The default model is
+``gpt-5.4-mini``.
 
 .. code-block:: bash
 
@@ -180,31 +205,41 @@ Uses GPT-4.1 vision. Requires ``OPENAI_API_KEY``.
 .. code-block:: python
 
    ocr = OCR("openai")
-   ocr = OCR("openai", model="gpt-4o-mini")                       # cheaper model
+   ocr = OCR("openai", model="gpt-5.4-mini")                       # explicit default
    ocr = OCR("openai", base_url="http://localhost:11434/v1")       # Ollama / compatible
 
-Google Gemini
-~~~~~~~~~~~~~
+``base_url`` (or the ``OPENAI_BASE_URL`` env var) targets OpenAI-compatible
+endpoints. Model knobs follow the precedence **explicit constructor argument ->
+OCRConfig field -> built-in default**.
 
-Uses Gemini models via ``langchain-google-genai``. Both ``"vertex_ai"`` and
-``"gemini"`` are accepted as provider names. Authenticates with
-`Application Default Credentials <https://cloud.google.com/docs/authentication/application-default-credentials>`_.
+Google Gemini (Vertex AI)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Gemini via ``langchain-google-genai`` on the Vertex AI backend. Both
+``"vertex_ai"`` and ``"gemini"`` resolve to the same implementation.
+Authenticates with `Application Default Credentials
+<https://cloud.google.com/docs/authentication/application-default-credentials>`_
+rather than an API key. The default model is ``gemini-3.1-flash-lite-preview``
+and the default location is ``"global"``.
 
 .. code-block:: bash
 
    pip install "doc2mark[vertex_ai]"
    export GOOGLE_APPLICATION_CREDENTIALS=/path/to/key.json
+   export GOOGLE_CLOUD_PROJECT=my-gcp-project
 
 .. code-block:: python
 
    ocr = OCR("gemini")
-   ocr = OCR("vertex_ai", model="gemini-2.0-flash")
+   ocr = OCR("vertex_ai", project="my-gcp-project", model="gemini-3.1-flash-lite-preview")
 
 Tesseract (offline)
 ~~~~~~~~~~~~~~~~~~~
 
-Local OCR, no API key. Returns ``raw`` only (``interpretation`` is always
-``None``).
+Local OCR via ``pytesseract`` + Pillow, no API key. It is **raw-only**:
+``interpretation`` is always ``None`` (a non-LLM engine cannot infer document
+type, summaries, or confidence). ``language`` is mapped to a Tesseract language
+code (e.g. ``"chinese"`` -> ``chi_sim+chi_tra``), defaulting to English.
 
 .. code-block:: bash
 
@@ -212,25 +247,33 @@ Local OCR, no API key. Returns ``raw`` only (``interpretation`` is always
 
 .. code-block:: python
 
-   ocr = OCR("tesseract", language="eng")
+   ocr = OCR("tesseract", language="english")
+   r = ocr.read_one(scanned_png)
+   print(r.text)                               # transcription
+   print(r.document.interpretation)            # always None for Tesseract
+
 
 Concurrency
 -----------
 
-Control how many images are OCR'd in parallel:
+Control how many images the LLM providers OCR in parallel (inside LangChain's
+``batch_as_completed``):
 
 .. code-block:: python
 
    ocr = OCR("openai", max_concurrency=32)
 
-Or set the ``OCR_MAX_CONCURRENCY`` environment variable. When neither is set,
-LangChain's default thread pool is used.
+Or set the ``OCR_MAX_CONCURRENCY`` environment variable. Precedence is **explicit
+config value -> env var -> ``None``**, where ``None`` means "use the LangChain
+default" (a CPU-tied thread pool, typically ~12). Raise it to keep large scanned
+documents within an SLA (e.g. ``32`` for a several-thousand-page job).
+
 
 Using OCR with the document loader
 -----------------------------------
 
-:class:`~doc2mark.core.loader.UnifiedDocumentLoader` uses the OCR layer
-internally when ``ocr_images=True``:
+:class:`~doc2mark.UnifiedDocumentLoader` uses the OCR layer internally when
+``ocr_images=True``:
 
 .. code-block:: python
 
@@ -239,8 +282,7 @@ internally when ``ocr_images=True``:
    loader = UnifiedDocumentLoader(ocr_provider="openai")
    result = loader.load("scan.pdf", extract_images=True, ocr_images=True)
 
-Disabling OCR
--------------
+Disable OCR when it is not needed:
 
 .. code-block:: python
 
@@ -251,17 +293,26 @@ Disabling OCR
 
    doc2mark document.pdf --ocr none
 
+
 Deprecation notice
 ------------------
 
-The old ``OCRConfig`` fields ``enhance_image``, ``detect_tables``,
-``detect_layout``, ``timeout``, ``max_retries``, and ``extra`` are inert for
-LLM providers. Setting them now emits a ``DeprecationWarning`` and they will be
-removed in a future release. Use ``task`` and the structured output controls
+The old :class:`~doc2mark.ocr.OCRConfig` fields ``enhance_image``,
+``detect_tables``, ``detect_layout``, ``timeout``, ``max_retries``, and ``extra``
+are inert for the LLM providers (OpenAI / Vertex / Gemini). Setting any of them to
+a non-default value emits a single ``DeprecationWarning`` at construction, and
+they will be removed in a future release. (``enhance_image`` and ``detect_layout``
+remain live for the Tesseract provider.) Use the live knobs -- ``model``,
+``task``, ``language``, ``max_concurrency``, and the structured-output controls
+(``structured`` / ``detail`` / ``response_model`` / ``on_parse_error``) --
 instead.
 
-API reference
--------------
 
-See the full reference for the OCR facade, providers, and configuration in
-:doc:`/api/ocr`, and the structured result models in :doc:`/api/schema`.
+See also
+--------
+
+- :doc:`/tables` -- how transcribed tables (``Table.html``) flow into output.
+- :doc:`/contextual_ocr` -- attaching neighbor-page PDF context (``context_pages``).
+- :doc:`/ocr_policy` -- the ``auto`` router's classify-then-act extraction policy.
+- :doc:`/api/ocr` -- full facade, provider, and configuration reference.
+- :doc:`/api/schema` -- the complete structured result schema.

--- a/docs/ocr_policy.rst
+++ b/docs/ocr_policy.rst
@@ -219,9 +219,9 @@ never ``screenshot``.
 Neighbor-page context tightens the gate
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-When neighbor-page PDF context is attached (``context_pages`` > 0, Gemini /
-Vertex only), the neighbors are read *only* to judge the host document's purpose
--- never transcribed. The non-verbatim policies (``describe`` and
+When neighbor-page PDF context is attached (``context_pages`` > 0, for any
+PDF-capable model -- OpenAI and Gemini alike), the neighbors are read *only* to
+judge the host document's purpose -- never transcribed. The non-verbatim policies (``describe`` and
 ``screenshot``) may then be applied **only** when the model's
 ``self_confidence >= 0.7`` *and* ``legibility == "high"``; otherwise, and
 whenever context is absent or conflicting, it falls back to verbatim.

--- a/docs/ocr_policy.rst
+++ b/docs/ocr_policy.rst
@@ -1,0 +1,302 @@
+Content-aware OCR policy
+========================
+
+doc2mark decides *how* to OCR a document from the document's **content**, not
+from its file extension. The same content-based routing applies to PDFs and to
+Office files, and it runs automatically: there are no routing flags to set. You
+turn OCR on (``ocr_images=True``) and doc2mark chooses the cheapest correct path
+for every page and every embedded image.
+
+The guiding principle
+---------------------
+
+Text, data, and tables take the **deterministic path** -- they are read directly
+from the document's structure (selectable text, ruled tables) and emitted
+*verbatim*. This path is exact, free (no model calls), and lossless: it is the
+authoritative source for the BM42 sparse-retrieval index, so every printed token
+is preserved character-for-character.
+
+Only a **true image-page** -- a slide or scan whose content is baked into
+pixels with no usable text layer -- is sent to an LLM vision model. The model is
+asked to transcribe that page verbatim and *also* synthesize a clean Markdown
+re-layout, but it is never allowed to drop real printed values.
+
+The policy is layered. Each layer narrows the decision:
+
+#. **Document strategy** -- one ``"image"`` vs ``"text"`` decision per document.
+#. **Office image route** -- image-dominant ``.docx``/``.pptx`` borrow the PDF
+   image strategy; text/table Office docs stay native.
+#. **Per-image job-router** -- when a single image is OCR'd, the model
+   classifies it and applies a per-type transcription policy.
+#. **page_markdown synthesis + coverage guard** -- for image pages a structured
+   Markdown rendering becomes the display body *only* when it provably covers
+   the verbatim text.
+
+The shared thresholds
+~~~~~~~~~~~~~~~~~~~~~~
+
+Both the document strategy and the Office route call one function,
+``doc2mark.core.strategy.decide_doc_strategy``, the single source of truth so
+the PDF and Office paths never diverge:
+
+.. code-block:: python
+
+   from doc2mark.core.strategy import decide_doc_strategy
+
+   # decide_doc_strategy(mean_image_coverage, mean_text_chars_per_page)
+   decide_doc_strategy(0.92, 35)    # -> "image"   (mostly pictures, no text layer)
+   decide_doc_strategy(0.70, 900)   # -> "text"    (large figures, but real text)
+   decide_doc_strategy(0.10, 1200)  # -> "text"    (ordinary text document)
+
+The two module constants are the only knobs, and they are deliberately not
+user-facing:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 32 14 54
+
+   * - Constant
+     - Value
+     - Meaning
+   * - ``IMAGE_PAGE_COVERAGE``
+     - ``0.55``
+     - Minimum mean fraction of page area covered by raster images for the
+       ``"image"`` strategy.
+   * - ``IMAGE_PAGE_TEXT_LIMIT``
+     - ``200``
+     - The mean selectable-text characters per page must be **below** this for
+       the ``"image"`` strategy.
+
+The rule is a logical AND::
+
+   "image"  iff  mean_image_coverage >= 0.55  AND  mean_text_chars_per_page < 200
+   "text"   otherwise
+
+Text density is the decisive signal. Coverage alone would misclassify a normal
+text document that merely carries a few large figures; requiring low text
+density as well keeps such documents on the deterministic ``"text"`` path.
+
+Layer 1 -- the document strategy
+--------------------------------
+
+For a PDF, ``PDFLoader._document_image_strategy`` computes the two signals
+deterministically and caches the result once per document:
+
+- ``mean_image_coverage`` -- the mean per-page fraction of page area covered by
+  raster images (capped at ``1.0``).
+- ``mean_text_chars_per_page`` -- the mean length of the page's stripped
+  selectable text.
+
+It feeds them to ``decide_doc_strategy`` and logs the decision, e.g.::
+
+   📑 Document OCR strategy: image (mean coverage 0.94, mean text 12 chars/page)
+
+A single uniform strategy is chosen for the whole document so that OCR-only and
+rule-based pages are never mixed.
+
+The ``"image"`` strategy
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Every page is rasterized to a single PNG (at 150 DPI) and OCR'd as one
+whole-page image. The whole-page transcription **is** the page's content: a
+sparse text layer on such a page is chrome (a logo, footer, or page number) that
+the whole-page OCR already captures, so the deterministic text layer is *not*
+also emitted -- emitting it would just duplicate tokens and add junk
+header/footer mini-tables.
+
+These whole-page renders also request ``page_markdown`` synthesis (Layer 4).
+
+The ``"text"`` strategy
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+The deterministic rule-based layer is authoritative:
+
+- **Tables** are detected with PyMuPDF's table finder and rendered with
+  doc2mark's table renderer (including merged-cell handling), so cell text stays
+  exact.
+- **Text** is extracted block-by-block and classified (title / section /
+  list / caption / footnote / header / footer) from font-size, weight, and
+  layout heuristics -- preserved verbatim for the BM42 RAG flow.
+- **Embedded figures** are OCR'd individually. Tiny decorative images (logos,
+  icons, bullets -- smaller than 10% of the page in *both* width and height) are
+  skipped before paying for extraction or an OCR call.
+
+Layer 2 -- the Office image route
+---------------------------------
+
+Office documents reach the *same* content-based decision, without a separate
+heuristic. ``OfficeProcessor._maybe_route_image_dominant`` runs before native
+extraction and is gated tightly:
+
+- Only ``.docx`` and ``.pptx`` are eligible. **``.xlsx`` never routes** -- a
+  spreadsheet is a data grid, always read natively.
+- OCR must be requested (both ``ocr_images=True`` and ``extract_images=True``)
+  and an OCR provider must be configured.
+
+``_is_image_dominant`` then computes the two signals straight from the OOXML
+structure -- no rendering required -- and calls the same
+``decide_doc_strategy``:
+
+- **PPTX** (``_pptx_image_signals``): mean picture-shape coverage and mean text
+  characters **per slide**.
+- **DOCX** (``_docx_image_signals``): total inline-picture coverage against one
+  page, and total paragraph text length. Totals suffice because a real
+  multi-page text document easily clears the 200-character limit, and
+  undercounting floating images biases toward ``"text"`` -- the safe direction.
+
+When the decision is ``"image"``, ``_process_as_image_dominant`` converts the
+file to PDF via LibreOffice and runs it through the PDF **image strategy**
+(whole-page render OCR + ``page_markdown`` synthesis), then restores the original
+Office identity in the metadata and records ``metadata.extra['routed_via'] =
+'pdf'``. Text/table Office docs stay on the native pipeline. The route never
+raises: any failure (including no LibreOffice on the host) falls back cleanly to
+native extraction.
+
+Layer 3 -- the per-image job-router (``task="auto"``)
+-----------------------------------------------------
+
+When an individual image is OCR'd -- a whole-page render, or an embedded figure
+on a ``"text"`` page -- the default task is ``auto``. The ``auto`` prompt is a
+self-routing job-router: the model first **classifies** the image into exactly
+one ``document_type``, then applies that type's transcription policy in the same
+response, recording the type in
+:attr:`Interpretation.document_type <doc2mark.ocr.schema.Interpretation>`.
+
+The master rule overrides every policy below it: **transcribe every legible
+printed character verbatim, in the original language.** Exactly one type --
+``screenshot`` -- may omit printed values, and only when *all three* gates hold:
+
+#. the image is a product / app / dashboard UI with toolbar, nav, tabs, or
+   buttons; **and**
+#. its data is clearly *illustrative* (round or sequential names, evenly spaced
+   dates, repeated amounts, "Sample"/"Demo"); **and**
+#. the surrounding context indicates a product, marketing, or feature
+   introduction.
+
+If any gate is missing -- or whenever the model is unsure -- it transcribes
+verbatim. A dropped real table is unrecoverable, so the tie always breaks toward
+verbatim.
+
+The four policies
+~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 18 20 62
+
+   * - Policy
+     - ``document_type``
+     - Behavior
+   * - **VERBATIM** (default)
+     - ``document``, ``table``, ``form``, ``receipt``, ``handwriting``,
+       ``code``, ``photo``, ``logo``, ``stamp``, ``mixed``, ``other``
+     - Transcribe every character into ``raw.text``; tables go to
+       ``raw.tables[].html`` with exact ``colspan``/``rowspan``; label/value
+       pairs to ``raw.fields``. ``content_fidelity="verbatim"``.
+   * - **SCREENSHOT** (triple-gated only)
+     - ``screenshot``
+     - Write only stable text -- screen/module name, section / nav / field /
+       column **labels**, buttons, capability message. Leave each
+       :class:`Table <doc2mark.ocr.schema.Table>` header-only with
+       ``illustrative=true`` and a ``row_count`` of the withheld sample rows;
+       put what the product *does* in ``interpretation``.
+       ``content_fidelity="described"``.
+   * - **DESCRIBE**
+     - ``chart``, ``diagram``, ``infographic``
+     - Keep **all** printed text verbatim (titles, axis / legend / node / edge
+       labels, printed numbers); never invent or pixel-estimate values; put the
+       trend / structure / message in ``interpretation``.
+       ``content_fidelity="described"``.
+   * - **SKIP**
+     - ``blank``
+     - Leave ``raw`` empty. ``content_fidelity="skipped"``.
+
+A ruled grid of irregular, varied-precision, or internally consistent numbers
+(subtotals that sum) is a *real* table and is transcribed as ``table``
+regardless of surrounding app chrome; monospace code or a terminal is ``code``,
+never ``screenshot``.
+
+Neighbor-page context tightens the gate
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When neighbor-page PDF context is attached (``context_pages`` > 0, Gemini /
+Vertex only), the neighbors are read *only* to judge the host document's purpose
+-- never transcribed. The non-verbatim policies (``describe`` and
+``screenshot``) may then be applied **only** when the model's
+``self_confidence >= 0.7`` *and* ``legibility == "high"``; otherwise, and
+whenever context is absent or conflicting, it falls back to verbatim.
+
+The ``router_invariants`` firewall
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``doc2mark.ocr.schema.router_invariants(page)`` is a mechanical check (returns a
+list of violation strings; empty means OK) that enforces the policy after the
+fact -- a BM42-safety net intended as a CI / eval assertion over recorded
+structured outputs. It guarantees that **real printed values are never withheld
+except on a high-confidence screenshot.** Among the invariants it checks:
+
+- Illustrative / withheld content (``illustrative=True`` on a table, field,
+  metric, or figure) may appear **only** when ``document_type == "screenshot"``.
+- A withholding screenshot must have ``self_confidence >= 0.7`` and
+  ``legibility == "high"`` -- otherwise it should have fallen back to verbatim.
+- ``content_fidelity`` of ``"described"`` / ``"caption"`` must carry meaning in
+  ``interpretation.summary``; ``"skipped"`` implies an empty ``raw`` layer.
+- ``interpretation.primary_date`` must be one of the verbatim strings in
+  ``raw.dates`` (selected, never invented).
+- Every verbatim string surfaced in a ``figure``, ``section``, typed entity, or
+  relation must be a substring of ``raw.text``.
+
+Layer 4 -- ``page_markdown`` synthesis and the coverage guard
+-------------------------------------------------------------
+
+For whole-page image renders only, doc2mark appends a synthesis instruction
+asking the model to *also* fill
+:attr:`Interpretation.page_markdown <doc2mark.ocr.schema.Interpretation>`: a
+clean, well-structured Markdown rendering of the page (headings, lists, arrow
+chains for flow diagrams) that **re-lays-out** the same text -- dropping,
+paraphrasing, and translating nothing. Table regions become a short
+``[see table]`` placeholder, since the authoritative HTML already lives in
+``raw.tables``.
+
+A flat OCR dump is hard to read, but a synthesized rendering risks summarizing
+content away. The coverage guard in
+:meth:`OCRPage.to_markdown <doc2mark.ocr.schema.OCRPage>` resolves the tension.
+``page_markdown`` is used as the display body **only** when it verifiably covers
+the verbatim text:
+
+- A token-based coverage score is computed over ``raw.text`` (Latin / numeric
+  words and CJK runs), against ``page_markdown`` plus the table HTML.
+- If coverage ``>= 0.85`` (``_SYNTH_COVERAGE_MIN``), the synthesized Markdown
+  becomes the body, the authoritative table HTML is appended, and any
+  still-missing verbatim tokens are preserved in a hidden ``raw-verbatim-tail``
+  HTML comment -- so BM42 keeps **every** token even if the rendering drops one.
+- If coverage falls below the floor (likely paraphrase or truncation), doc2mark
+  **falls back** to the standard verbatim rendering of ``raw.text`` + tables.
+
+The result is never lossy: the structured rendering is used when it is provably
+complete, and the raw verbatim dump is used otherwise.
+
+Putting it together
+-------------------
+
+Because the routing is automatic, the only thing you do is enable OCR:
+
+.. code-block:: python
+
+   from doc2mark import UnifiedDocumentLoader
+
+   loader = UnifiedDocumentLoader(ocr_provider="openai")
+
+   # A slide deck or scan -> "image" strategy: whole-page render OCR + page_markdown.
+   deck = loader.load("pitch_deck.pdf", extract_images=True, ocr_images=True)
+
+   # A text report -> "text" strategy: deterministic text/tables, verbatim,
+   # with only its embedded figures sent to the model.
+   report = loader.load("annual_report.pdf", extract_images=True, ocr_images=True)
+
+   # Same content-based decision for Office; an image-dominant .pptx is routed
+   # through the PDF image strategy, an ordinary .docx stays native.
+   slides = loader.load("slides.pptx", extract_images=True, ocr_images=True)
+
+See :doc:`/ocr` for the OCR facade, providers, tasks, and the structured-output
+schema, and :doc:`/api/schema` for the full model reference.

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -1,13 +1,22 @@
 Quickstart
 ==========
 
-Install the package:
+doc2mark turns documents (PDF, Office, images, text/data, and legacy Office
+files) into clean Markdown or structured Python objects. Text-only extraction
+needs no API keys; OCR providers are initialized only when you actually ask
+for OCR.
+
+Install
+-------
 
 .. code-block:: bash
 
    pip install doc2mark
 
-Load a document:
+The 30-second example
+---------------------
+
+Load a PDF and read the Markdown:
 
 .. code-block:: python
 
@@ -16,30 +25,134 @@ Load a document:
    loader = UnifiedDocumentLoader()
    result = loader.load("document.pdf")
 
-   print(result.content)
-   print(result.metadata.filename)
+   print(result.content)            # Markdown string
+   print(result.metadata.filename)  # document.pdf
 
-Use the convenience function for one-off conversions:
+``result`` is a :class:`~doc2mark.ProcessedDocument`. Its most useful fields:
+
+- ``content`` -- the rendered output (Markdown by default).
+- ``metadata`` -- a :class:`~doc2mark.DocumentMetadata` (``filename``,
+  ``format``, ``size_bytes``, ``page_count``, ...).
+- ``tables`` / ``images`` / ``sections`` / ``json_content`` -- structured
+  extras, populated depending on the format and options.
+
+For one-off conversions there is a module-level :func:`~doc2mark.load` helper
+that builds a loader for you:
 
 .. code-block:: python
 
    from doc2mark import load
 
-   result = load("report.docx")
-   markdown = result.content
+   markdown = load("report.docx").content
 
-Structured Output
------------------
+Output formats
+--------------
 
-Every load returns a :class:`doc2mark.ProcessedDocument`.
+``load()`` accepts an ``output_format`` of ``"markdown"`` (default),
+``"json"``, or ``"text"`` (the :class:`~doc2mark.OutputFormat` enum values
+``MARKDOWN``, ``JSON``, ``TEXT``).
 
 .. code-block:: python
 
-   payload = result.to_dict()
-   print(payload["metadata"]["format"])
+   from doc2mark import UnifiedDocumentLoader
 
-Batch Processing
+   loader = UnifiedDocumentLoader()
+
+   # Markdown (default)
+   md = loader.load("document.pdf").content
+
+   # JSON: result.content is a JSON string; result.json_content is the
+   # structured list of content blocks (handy for chunking / RAG).
+   doc = loader.load("document.pdf", output_format="json")
+   print(doc.content)         # JSON string
+   print(doc.json_content)    # list of {"type": ..., "content": ...} blocks
+
+   # Plain text: layout and Markdown markup stripped out
+   text = loader.load("document.pdf", output_format="text").content
+
+Every result can also be turned into a plain dict with ``result.to_dict()``
+(the same payload the CLI writes for ``--format json``).
+
+Text-only vs OCR
 ----------------
+
+By default doc2mark does **not** call any OCR model -- it extracts the text
+that already lives in the file. This path needs no credentials and is the
+right choice for digital PDFs and Office documents.
+
+To describe images embedded in a document, opt in with two flags:
+
+.. code-block:: python
+
+   from doc2mark import UnifiedDocumentLoader
+
+   loader = UnifiedDocumentLoader(ocr_provider="openai")  # reads OPENAI_API_KEY
+
+   result = loader.load(
+       "scanned.pdf",
+       extract_images=True,   # pull images out of the document
+       ocr_images=True,       # run OCR on those images
+   )
+
+``ocr_images=True`` requires ``extract_images=True``. With
+``extract_images=True, ocr_images=False`` images are kept as base64 data
+instead of being described.
+
+Picking a provider
+------------------
+
+Pass ``ocr_provider`` to the loader (or to :func:`~doc2mark.load`). Built-in
+providers: ``"openai"`` (default), ``"vertex_ai"`` (Google Gemini), and
+``"tesseract"`` (local, no API key). Use ``ocr_provider=None`` to disable OCR
+entirely.
+
+.. code-block:: python
+
+   # OpenAI (default model: gpt-5.4-mini). Reads OPENAI_API_KEY by default.
+   loader = UnifiedDocumentLoader(ocr_provider="openai")
+
+   # Google Vertex AI / Gemini (default model: a gemini-3.x flash model).
+   loader = UnifiedDocumentLoader(
+       ocr_provider="vertex_ai",
+       project="my-gcp-project",   # or GOOGLE_CLOUD_PROJECT env var
+   )
+
+   # Local Tesseract -- no network, no API key.
+   loader = UnifiedDocumentLoader(ocr_provider="tesseract")
+
+You can override the model and other knobs on the constructor, e.g.
+``UnifiedDocumentLoader(ocr_provider="openai", model="gpt-5.4-mini",
+temperature=0)``. See :doc:`/ocr` for the full set of OCR options.
+
+From the command line
+---------------------
+
+The ``doc2mark`` CLI mirrors the Python API:
+
+.. code-block:: bash
+
+   # Single file to stdout (Markdown)
+   doc2mark document.pdf
+
+   # Save Markdown
+   doc2mark document.pdf -o output.md
+
+   # JSON output
+   doc2mark document.pdf --format json -o output.json
+
+   # OCR a scanned PDF with OpenAI (implies --extract-images)
+   doc2mark scanned.pdf --ocr openai --ocr-images
+
+   # Process a directory recursively, 4 files in parallel
+   doc2mark docs/ -r -p 4 -o out/
+
+OCR is off by default in the CLI (``--ocr none``). See :doc:`/cli` for every
+flag.
+
+Batch processing
+----------------
+
+Convert a whole directory in one call:
 
 .. code-block:: python
 
@@ -51,43 +164,18 @@ Batch Processing
        output_dir="converted",
        recursive=True,
        save_files=True,
+       max_workers=4,   # process files concurrently
    )
 
-Document Cache
---------------
+``batch_process`` returns a dict mapping each input path to a per-file result
+(status, output files, and metadata).
 
-Set ``cache_dir`` to persist processed documents between calls:
+Where to next
+-------------
 
-.. code-block:: python
-
-   loader = UnifiedDocumentLoader(cache_dir=".doc2mark-cache")
-   result = loader.load("report.pdf")
-
-Chunking for RAG
-----------------
-
-Split structured output into section-aware chunks for retrieval-augmented
-generation pipelines:
-
-.. code-block:: python
-
-   from doc2mark import load, chunk_content, ChunkingConfig
-
-   result = load("report.pdf", output_format="json")
-
-   config = ChunkingConfig(
-       max_chunk_size=1500,       # max characters per chunk
-       overlap=200,               # character overlap between consecutive chunks
-       split_on_heading_level=2,  # split on h1 and h2 headings
-       keep_tables_whole=True,    # avoid splitting tables across chunks
-       include_page_markers=False,
-   )
-
-   chunks = chunk_content(result.json_content, config)
-
-   for chunk in chunks:
-       print(chunk.chunk_index, chunk.section_title, len(chunk.content))
-
-Each :class:`~doc2mark.Chunk` carries ``section_title``,
-``section_hierarchy``, ``page_start``, ``page_end``, ``content_types``, and
-``chunk_index`` metadata.
+- :doc:`/formats` -- every supported file type and how each is parsed.
+- :doc:`/ocr` -- OCR providers, models, tasks, and structured output.
+- :doc:`/ocr_policy` -- when OCR runs and how to keep extraction text-only.
+- :doc:`/tables` -- table extraction and merged-cell (rowspan/colspan) output.
+- :doc:`/contextual_ocr` -- richer, structured OCR interpretation of images.
+- :doc:`/caching` -- document and OCR caching to avoid repeat work.

--- a/docs/tables.rst
+++ b/docs/tables.rst
@@ -1,0 +1,300 @@
+Complex Table Preservation
+==========================
+
+Tables are where naive document conversion loses the most information. A budget
+sheet with a group header that spans three quarters, or an invoice with a row
+label that spans two line items, collapses into a flat ``| a | b | c |`` grid the
+moment you ignore merged cells. doc2mark keeps those spans intact.
+
+The key design decision: for **digital** documents (PDFs with a real text layer,
+and Office files), doc2mark reconstructs tables with a **deterministic,
+rule-based path** -- not the vision/OCR model. The geometry and the markup are
+already in the file, so doc2mark reads them directly. OCR is reserved for images
+and scanned pages where there is no structure to recover.
+
+Why rule-based instead of OCR
+-----------------------------
+
+A whole-page OCR pass *describes* a table; the rule-based path *reconstructs* it
+from ground truth:
+
+* **PDFs** carry vector cell boundaries. doc2mark asks PyMuPDF for the table
+  grid and the per-cell bounding boxes, then infers ``rowspan`` / ``colspan``
+  from the geometry -- no model guessing required.
+* **Office files** (DOCX / PPTX / XLSX) store merges explicitly in OOXML
+  (``w:gridSpan`` / ``w:vMerge`` for Word, ``gridSpan`` / ``vMerge`` for
+  PowerPoint, ``merged_cells.ranges`` for Excel). doc2mark reads those
+  attributes directly, so the merge map is exact.
+
+This matters empirically. Native extraction reproduces **every** span
+cell-accurately, including the common 2-wide column merge (a header sitting over
+two adjacent columns). Whole-page OCR tends to *under-apply* those narrow merges
+-- it transcribes the text but flattens the 2-column header back into a single
+cell -- which silently corrupts the grid. Because the rule-based path is exact
+where OCR is lossy, complex tables in digital documents stay on the rule-based
+path and never round-trip through the vision model.
+
+The PDF path: geometric span detection
+--------------------------------------
+
+For each page, :class:`~doc2mark.core.loader.UnifiedDocumentLoader` (via its
+PyMuPDF pipeline) calls ``page.find_tables()`` and, for every detected table,
+runs ``_convert_table_to_markdown_enhanced``. That method:
+
+#. Extracts cell text per cell with de-duplication of overlapping spans, so
+   text that visually straddles a boundary is not double-counted.
+#. Calls ``_analyze_table_with_boundaries`` to build a normalized grid.
+
+``_analyze_table_with_boundaries`` prefers **true geometry** when PyMuPDF exposes
+per-cell boxes: ``_get_cell_boundaries`` reads each cell's bounding box, and
+``_detect_merges_from_boundaries`` checks, via ``_bboxes_overlap_significantly``
+(default 80% overlap), how many logical grid positions a single physical box
+covers. A box that covers two columns becomes ``colspan=2``; one that covers two
+rows becomes ``rowspan=2``.
+
+When per-cell boxes are unavailable, it falls back to a conservative
+**empty-cell** heuristic with explicit guards against false positives on sparse
+data:
+
+* It pre-computes, per column, the fraction of empty cells. A column that is
+  more than 50% empty is treated as *legitimately sparse* (``col_mostly_empty``)
+  and is **not** read as a merge.
+* **First pass -- colspans:** a non-empty cell absorbs trailing empty cells to
+  its right *only* when those columns are not mostly-empty; absorbed positions
+  are recorded so they cannot also be claimed as rowspans.
+* **Second pass -- rowspans:** a non-empty cell (not already part of a colspan,
+  not in a mostly-empty column) absorbs empty cells directly below it.
+
+The result is a ``TableData`` object (from ``doc2mark.core.table``) with the
+spans attached.
+
+The Office path: OOXML grid spans
+---------------------------------
+
+The Office pipeline reads the merge map straight from the markup rather than
+guessing from blank cells.
+
+* **Word (DOCX):** for each ``w:tc`` cell, ``w:gridSpan/@w:val`` gives the
+  ``colspan``. ``w:vMerge`` gives vertical merges: ``val="restart"`` opens a
+  rowspan and ``val="continue"`` (or a bare ``w:vMerge``) extends it. A second
+  pass counts the continuation rows under each ``restart`` cell to compute the
+  final ``rowspan``. This is an O(n*m) attribute read, not an O(n^2*m^2)
+  cell-identity comparison.
+* **PowerPoint (PPTX):** each cell's ``gridSpan`` and ``vMerge`` properties are
+  read off the shape's table; continuation cells are blank, and the origin cell
+  accumulates ``rowspan`` / ``colspan``.
+* **Excel (XLSX):** ``merged_cells.ranges`` gives merge rectangles directly; the
+  span is ``max_row - min_row + 1`` by ``max_col - min_col + 1``, with spans
+  re-clamped when columns inside the range are dropped.
+
+All three converge on the same ``TableData`` structure used by the PDF path.
+
+From ``TableData`` to clean HTML
+--------------------------------
+
+``TableData`` is a validated, self-normalizing grid. Its model validators:
+
+* pad ragged rows to a rectangle,
+* clamp every span to the table bounds (a ``rowspan`` can never run past the last
+  row),
+* mark the positions covered by a span as *continuation* cells, and
+* auto-set ``is_complex = True`` when any span is present.
+
+A ``TableRenderer`` then renders it. The renderer chooses its output from the
+``table_style`` you configured (see below). For a complex table the default
+**minimal HTML** renderer emits one ``<tr>`` per visual row, writes ``<th>`` for
+the first physical row and ``<td>`` elsewhere, attaches ``rowspan`` / ``colspan``
+only when greater than 1, **skips continuation cells entirely**, and
+HTML-escapes ``&``, ``<``, ``>``. Simple (span-free) tables render as ordinary
+pipe-delimited Markdown instead.
+
+Choosing the output style
+-------------------------
+
+The loader exposes ``table_style``, which maps to :class:`~doc2mark.TableStyle`:
+
+.. code-block:: python
+
+   from doc2mark import UnifiedDocumentLoader
+
+   loader = UnifiedDocumentLoader(table_style="minimal_html")
+   doc = loader.load("quarterly_report.pdf")
+
+The three accepted values (string or enum) are:
+
+``minimal_html`` (default)
+   Clean ``<table>`` with only ``rowspan`` / ``colspan`` attributes -- the
+   recommended style for downstream Markdown and RAG.
+
+``markdown_grid``
+   A Markdown grid that keeps cell alignment and records merges as an
+   ``<!-- Merged: R1C2:1x3, ... -->`` comment plus ``⊕`` / ``→`` / ``↓`` span
+   markers, for pipelines that must stay pure-Markdown.
+
+``styled_html``
+   Full HTML with inline ``border`` / ``style`` attributes (legacy; verbose).
+
+Worked example: a merged-cell table
+------------------------------------
+
+Consider revenue by region and country, with a group header spanning the three
+year columns and a region label spanning two country rows:
+
+.. code-block:: text
+
+   +----------+----------+-----------------------------+
+   |          |          |        Revenue (USD)        |   <- spans 3 columns
+   +----------+----------+--------+--------+-----------+
+   | Region   | Country  |  2023  |  2024  |   2025    |
+   +----------+----------+--------+--------+-----------+
+   | Americas | USA      | $4.2B  | $4.8B  |   $5.1B   |   <- "Americas"
+   +  (spans  +----------+--------+--------+-----------+      spans 2 rows
+   |  2 rows) | Canada   | $0.9B  | $1.0B  |   $1.1B   |
+   +----------+----------+--------+--------+-----------+
+   | EMEA     | Germany  | $2.1B  | $2.3B  |   $2.5B   |
+   +----------+----------+--------+--------+-----------+
+
+The geometry (PDF) or the ``gridSpan`` / ``vMerge`` markup (Office) yields a
+``colspan=3`` on *Revenue (USD)* and a ``rowspan=2`` on *Americas*. With the
+default ``minimal_html`` style, doc2mark emits exactly:
+
+.. code-block:: text
+
+   <table>
+   <tr>
+   <th></th>
+   <th></th>
+   <th colspan="3">Revenue (USD)</th>
+   </tr>
+   <tr>
+   <td>Region</td>
+   <td>Country</td>
+   <td>2023</td>
+   <td>2024</td>
+   <td>2025</td>
+   </tr>
+   <tr>
+   <td rowspan="2">Americas</td>
+   <td>USA</td>
+   <td>$4.2B</td>
+   <td>$4.8B</td>
+   <td>$5.1B</td>
+   </tr>
+   <tr>
+   <td>Canada</td>
+   <td>$0.9B</td>
+   <td>$1.0B</td>
+   <td>$1.1B</td>
+   </tr>
+   <tr>
+   <td>EMEA</td>
+   <td>Germany</td>
+   <td>$2.1B</td>
+   <td>$2.3B</td>
+   <td>$2.5B</td>
+   </tr>
+   </table>
+
+Note the two empty top-left ``<th></th>`` corner cells are preserved (they
+anchor the row/column header axes), the group header is a single
+``<th colspan="3">`` rather than three separate cells, and *Americas* appears
+once as ``<td rowspan="2">`` -- the *Canada* row omits its first cell because that
+position is a continuation of the span. The renderer marks only the first
+physical row as ``<th>``; the *Region / Country / 2023...* sub-header row is
+emitted as ``<td>``.
+
+The OCR table path and ``Table.html``
+-------------------------------------
+
+When a table *is* an image (a scanned page, or a screenshot region), there is no
+geometry to read, so it goes through the OCR layer instead. Each image becomes an
+:class:`~doc2mark.ocr.schema.OCRPage`, and any tables land in
+``page.raw.tables`` as :class:`~doc2mark.ocr.schema.Table` objects. The same
+``rowspan`` / ``colspan`` idea applies, but the HTML now comes from the vision
+model, so it is **sanitized at the model boundary** before it is ever stored or
+rendered.
+
+:class:`~doc2mark.ocr.schema.Table` carries several views of the same table:
+
+* ``html`` -- the preferred representation; a clean ``<table>`` that can encode
+  merged cells via ``colspan`` / ``rowspan``.
+* ``headers`` / ``rows`` -- a best-effort flat view for simple machine access.
+* ``markdown`` -- a rendered Markdown fallback for simple (non-merged) tables.
+* ``caption`` -- the table caption, if any.
+* ``illustrative`` -- ``True`` when the table holds demo/sample values (e.g. a
+  product-screenshot mockup) rather than real data, so indexers can down-weight
+  it.
+* ``row_count`` -- for a header-only ``illustrative`` table, how many sample rows
+  were intentionally not transcribed.
+
+The ``html`` field runs through ``doc2mark.ocr.schema.sanitize_table_html`` as a
+Pydantic validator, so the stored value is always safe to embed. The sanitizer:
+
+* keeps only table-structural tags -- ``table``, ``thead``, ``tbody``,
+  ``tfoot``, ``tr``, ``th``, ``td``, ``caption``, ``col``, ``colgroup`` -- and
+  **unwraps** every other tag while preserving its inner text;
+* keeps only the ``colspan``, ``rowspan``, and ``scope`` attributes (dropping
+  classes, ids, inline styles, URLs, event handlers, and everything else), and
+  drops ``colspan`` / ``rowspan`` whose value is not an integer;
+* strips dangerous elements entirely (``script``, ``style``, ``iframe``,
+  ``object``, ``embed``, ``form``, ``svg``, ``math``, and similar);
+* tolerates a model wrapping its output in a ``` ```html ``` code fence; and
+* **fails closed** -- it returns ``""`` for empty or unparseable input, so
+  unsanitized model HTML is never emitted.
+
+``to_markdown()`` prefers ``html``
+----------------------------------
+
+:meth:`~doc2mark.ocr.schema.OCRPage.to_markdown` renders a single readable
+Markdown string from a page and is the source of the back-compat
+``OCRResult.text``. For each table in ``raw.tables`` it follows a strict
+preference order so merged cells survive:
+
+#. ``table.html`` (the sanitized HTML with spans) -- used whenever present;
+#. else ``table.markdown`` (the rendered simple-table fallback);
+#. else a Markdown table reconstructed from ``table.headers`` / ``table.rows``.
+
+So if the model produced span-bearing HTML, ``to_markdown()`` keeps it verbatim
+rather than degrading to a flat header/row grid.
+
+Reading tables from a result
+----------------------------
+
+**Digital documents (rule-based path).** ``loader.load(...)`` returns a
+:class:`~doc2mark.ProcessedDocument`. The rendered table HTML is embedded inline
+in ``doc.content``, and each table is also a discrete item in
+``doc.json_content`` with ``type == "table"``:
+
+.. code-block:: python
+
+   from doc2mark import UnifiedDocumentLoader, OutputFormat
+
+   loader = UnifiedDocumentLoader(table_style="minimal_html")
+   doc = loader.load("quarterly_report.docx", output_format=OutputFormat.JSON)
+
+   for item in doc.json_content or []:
+       if item["type"] == "table":
+           print(item["content"])     # the <table>...</table> string with spans
+
+**Image OCR (vision path).** When you OCR an image directly, the structured
+table objects live on the page:
+
+.. code-block:: python
+
+   from doc2mark import OCR
+
+   ocr = OCR("openai")
+   result = ocr.read_one(image_bytes)        # -> OCRResult
+
+   page = result.document                    # OCRPage
+   for table in page.raw.tables:             # list[Table]
+       print(table.caption)
+       print(table.html)                     # sanitized HTML, colspan/rowspan
+       if not table.html:
+           print(table.headers, table.rows)  # flat fallback view
+
+   print(result.text)                        # to_markdown(): prefers table.html
+
+In both paths the merged-cell structure is preserved: as exact, geometry- or
+markup-derived HTML for digital documents, and as sanitized model HTML for
+images.


### PR DESCRIPTION
## Summary

Enriches and resyncs the Sphinx documentation with the current codebase. (All the
code changes from this line of work are already on `main`; this PR is the
documentation that had drifted behind it.)

## New feature pages

- **`docs/tables.rst` — Complex table preservation (rule-based).** How merged cells
  survive deterministically: PyMuPDF geometric span detection + OOXML
  `gridSpan`/`vMerge`/`merged_cells.ranges` → `Table.html` with `colspan`/`rowspan`
  (sanitized to a strict tag allowlist), `to_markdown()` html-first, a worked
  merged-cell example with the exact emitted HTML, and why the rule-based path is
  cell-accurate where whole-page OCR under-applies 2-wide column merges.
- **`docs/contextual_ocr.rst` — Contextual OCR strategy.** The neighbor-page
  `{k-1, k, k+1}` window PDF attached as *context* (not transcribed) to anchor
  terminology/names/language; `context_pages` tiers, the size-guarded/cached window
  builder, and the OpenAI + Gemini attachment formats.
- **`docs/ocr_policy.rst` — Content-aware OCR policy.** The layered routing: the
  two-signal document strategy (`core.strategy`), the Office image-dominance route,
  the per-image job-router + `router_invariants` firewall, and `page_markdown`
  synthesis with the coverage guard — framed as "text/data/tables go the
  deterministic path; only true image-pages get LLM OCR."
- **`docs/formats.rst`** — every supported input and the processor that handles it.

## Resync (drift an audit found)

- Removed `interpretation.reading_order` (deleted field); corrected `document_type`
  to its 16 values.
- Default model `gpt-4.1`/`gpt-4o-mini` → **`gpt-5.4-mini`**; `max_tokens` 4096 → **8192**.
- Documented the new `raw` fields (`headings`/`dates`/`metrics`) and `interpretation`
  fields (`figures`/`sections`/`typed_entities`/`relations`/`page_markdown`/…) and
  `Table.html`.
- Dropped the rot-prone hand-written field tables in `api/schema.rst` — `autoclass`
  is now the single source of truth, so they can't drift again.

## Verification

- Builds clean under `sphinx -b html -W` (warnings = errors).
- The three feature pages were human-verified against the source — every cited
  internal symbol, constant, and threshold checked out; the one factual error found
  (neighbor-context wrongly described as "Gemini/Vertex only") was corrected.

## Deploy

Publishes to GitHub Pages on merge (one-time: repo **Settings → Pages → Source:
GitHub Actions**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
